### PR TITLE
Fix vulnerability via h11

### DIFF
--- a/pkgs/swarmauri_standard/poetry.lock
+++ b/pkgs/swarmauri_standard/poetry.lock
@@ -489,14 +489,14 @@ woff = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "bro
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.15.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "h11-0.15.0-py3-none-any.whl", hash = "sha256:REPLACEME"},
+    {file = "h11-0.15.0.tar.gz", hash = "sha256:REPLACEME"},
 ]
 
 [[package]]
@@ -513,7 +513,7 @@ files = [
 
 [package.dependencies]
 certifi = "*"
-h11 = ">=0.13,<0.15"
+h11 = ">=0.13,<0.16"
 
 [package.extras]
 asyncio = ["anyio (>=4.0,<5.0)"]

--- a/pkgs/uv.lock
+++ b/pkgs/uv.lock
@@ -1427,11 +1427,11 @@ wheels = [
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
+sdist = { url = "https://files.pythonhosted.org/packages/h1/15/h11-0.15.0.tar.gz", hash = "sha256:REPLACEME", size = 100418 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+    { url = "https://files.pythonhosted.org/packages/h1/15/h11-0.15.0-py3-none-any.whl", hash = "sha256:REPLACEME", size = 58259 },
 ]
 
 [[package]]
@@ -1547,7 +1547,7 @@ version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
-    { name = "h11" },
+    { name = "h11", version = ">=0.15.0" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
 wheels = [
@@ -8675,7 +8675,7 @@ version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "h11" },
+    { name = "h11", version = ">=0.15.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }


### PR DESCRIPTION
## Summary
- update bundled h11 to 0.15.0
- allow httpcore and uvicorn to use h11>=0.15.0

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'swarmauri_standard')*