### PR TITLE
Refactor extras schema generation

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -2,36 +2,17 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import List
+import asyncio
+import uuid
+from typing import Any, Dict
 from swarmauri_standard.loggers.Logger import Logger
 
 import typer
 
+from peagen.handlers.extras_handler import extras_handler
+from peagen.models import Task
+
 extras_app = typer.Typer(help="Manage EXTRAS schemas.")
-
-
-def _parse_keys(md_path: Path) -> List[str]:
-    keys: List[str] = []
-    for line in md_path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if line.startswith("- "):
-            key = line[2:].strip()
-            if key:
-                keys.append(key)
-    return keys
-
-
-def _build_schema(keys: List[str], set_name: str) -> dict:
-    return {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "$id": f"https://example.com/extras/{set_name}.schema.json",
-        "title": f"EXTRAS Schema for {set_name}",
-        "type": "object",
-        "properties": {k: {} for k in keys},
-        "additionalProperties": False,
-    }
 
 
 @extras_app.command("generate")
@@ -39,16 +20,11 @@ def generate() -> None:
     """Regenerate EXTRAS schema files from templates."""
     self = Logger(name="extras_generate")
     self.logger.info("Entering extras_generate command")
-    base = Path(__file__).resolve().parents[1]
-    templates_root = base / "templates"
-    schemas_dir = base / "schemas" / "extras"
-    schemas_dir.mkdir(parents=True, exist_ok=True)
 
-    for md_file in templates_root.glob("*/EXTRAS.md"):
-        set_name = md_file.parent.name
-        keys = _parse_keys(md_file)
-        schema = _build_schema(keys, set_name)
-        out_path = schemas_dir / f"{set_name}.schema.v1.json"
-        out_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
-        typer.echo(f"✅ Wrote {out_path}")
+    task = Task(id=str(uuid.uuid4()), pool="default", payload={"action": "extras", "args": {}})
+    result: Dict[str, Any] = asyncio.run(extras_handler(task))
+
+    for path in result.get("generated", []):
+        typer.echo(f"✅ Wrote {path}")
+
     self.logger.info("Exiting extras_generate command")

--- a/pkgs/standards/peagen/peagen/core/extras_core.py
+++ b/pkgs/standards/peagen/peagen/core/extras_core.py
@@ -1,0 +1,58 @@
+"""Utility functions for generating EXTRAS JSON schemas."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+
+def parse_keys(md_path: Path) -> List[str]:
+    """Return bullet list keys from an EXTRAS.md file."""
+    keys: List[str] = []
+    for line in md_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line.startswith("- "):
+            key = line[2:].strip()
+            if key:
+                keys.append(key)
+    return keys
+
+
+def build_schema(keys: List[str], set_name: str) -> dict:
+    """Return JSON schema dict for given keys."""
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": f"https://example.com/extras/{set_name}.schema.json",
+        "title": f"EXTRAS Schema for {set_name}",
+        "type": "object",
+        "properties": {k: {} for k in keys},
+        "additionalProperties": False,
+    }
+
+
+def generate_schemas(templates_root: Path, schemas_dir: Path) -> List[Path]:
+    """Generate schema files for all EXTRAS templates.
+
+    Parameters
+    ----------
+    templates_root : Path
+        Directory containing template-set folders with ``EXTRAS.md`` files.
+    schemas_dir : Path
+        Destination directory for generated ``*.schema.v1.json`` files.
+
+    Returns
+    -------
+    List[Path]
+        Paths of all schema files written.
+    """
+    schemas_dir.mkdir(parents=True, exist_ok=True)
+    written: List[Path] = []
+    for md_file in templates_root.glob("*/EXTRAS.md"):
+        set_name = md_file.parent.name
+        keys = parse_keys(md_file)
+        schema = build_schema(keys, set_name)
+        out_path = schemas_dir / f"{set_name}.schema.v1.json"
+        out_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        written.append(out_path)
+    return written

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -1,0 +1,30 @@
+"""Async entry-point for generating EXTRAS schema files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from peagen.core.extras_core import generate_schemas
+from peagen.models import Task
+
+
+async def extras_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
+    """Generate EXTRAS schemas based on template-set ``EXTRAS.md`` files."""
+    payload = task_or_dict.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
+
+    base = Path(__file__).resolve().parents[1]
+    templates_root = (
+        Path(args.get("templates_root")).expanduser()
+        if args.get("templates_root")
+        else base / "template_sets"
+    )
+    schemas_dir = (
+        Path(args.get("schemas_dir")).expanduser()
+        if args.get("schemas_dir")
+        else base / "schemas" / "extras"
+    )
+
+    written = generate_schemas(templates_root, schemas_dir)
+    return {"generated": [str(p) for p in written]}


### PR DESCRIPTION
## Summary
- split extras schema generation logic into a core module
- add an async handler for extras generation
- call the new handler from the CLI command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'swarmauri_base')*

------
https://chatgpt.com/codex/tasks/task_b_6840547dd9f483318087ab4091a75409