### PR TITLE
Refactor template-set commands

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -8,14 +8,14 @@ Wire it in peagen/cli.py with:
     app.add_typer(template_sets_app, name="template-sets")
 """
 
-import importlib.metadata as im
-import shutil
-import subprocess
-import sys
-from pathlib import Path
-from typing import Dict, List, Optional
+from __future__ import annotations
 
-import peagen.template_sets as _pt  # root namespace that ships built-in sets
+import asyncio
+import uuid
+from typing import Any, Dict, Optional
+
+from peagen.handlers.templates_handler import templates_handler
+from peagen.models import Task
 import typer
 
 # ──────────────────────────────────────
@@ -26,35 +26,9 @@ template_sets_app = typer.Typer(
 
 
 # ─── helpers ───────────────────────────
-def _namespace_dirs() -> List[Path]:
-    """Return the search roots that may contain template-set folders."""
-    return [Path(p) for p in _pt.__path__]
-
-
-def _discover_template_sets() -> Dict[str, List[Path]]:
-    """
-    Build a mapping  SET_NAME -> [<all physical locations that provide it>].
-    """
-    sets: Dict[str, List[Path]] = {}
-    for ns_root in _namespace_dirs():
-        try:
-            for child in ns_root.iterdir():
-                if child.is_dir():
-                    sets.setdefault(child.name, []).append(child)
-        except PermissionError:
-            # Skip unreadable roots but keep going.
-            continue
-    # also gather sets exposed via entry-points so wheels without a physical
-    # folder in peagen.templates still show up.
-    for ep in im.entry_points(group="peagen.template_sets"):
-        try:
-            pkg = ep.load()  # this is now the module object
-            for root in getattr(pkg, "__path__", []):  # pkg.__path__ is a list of dirs
-                sets.setdefault(ep.name, []).append(Path(root))
-        except Exception as e:
-            print(f"⚠️  could not load plugin {ep.name!r}: {e}")
-            continue
-    return sets
+def _run_handler(args: Dict[str, Any]) -> Dict[str, Any]:
+    task = Task(id=str(uuid.uuid4()), pool="default", payload={"args": args})
+    return asyncio.run(templates_handler(task))
 
 
 # ─── list ──────────────────────────────
@@ -68,7 +42,8 @@ def list_template_sets(
         help="-v shows physical paths.",
     ),
 ):
-    discovered = _discover_template_sets()
+    result = _run_handler({"operation": "list", "verbose": verbose})
+    discovered = {e["name"]: e.get("paths", []) for e in result.get("sets", [])}
     if not discovered:
         typer.echo("⚠️  No template-sets found.")
         raise typer.Exit(code=1)
@@ -79,7 +54,7 @@ def list_template_sets(
         if verbose:
             for p in paths:
                 typer.echo(f"     ↳ {p}")
-    typer.echo(f"\nTotal: {len(discovered)} set(s)")
+    typer.echo(f"\nTotal: {result['total']} set(s)")
 
 
 # ─── show ──────────────────────────────
@@ -94,33 +69,23 @@ def show_template_set(
         help="-v lists files, -vv lists full paths.",
     ),
 ):
-    discovered = _discover_template_sets()
-    if name not in discovered:
-        typer.echo(f"❌  Template-set '{name}' not found.")
+    try:
+        info = _run_handler({"operation": "show", "name": name, "verbose": verbose})
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"❌  {exc}")
         raise typer.Exit(code=1)
 
-    # first hit wins unless user asked for more detail
-    primary_path = discovered[name][0]
-    typer.echo(f"\nTemplate-set: {name}")
-    typer.echo(f"Location:    {primary_path}")
+    typer.echo(f"\nTemplate-set: {info['name']}")
+    typer.echo(f"Location:    {info['location']}")
 
-    if len(discovered[name]) > 1 and verbose:
+    if info.get("other_locations") and verbose:
         typer.echo("\n⚠️  Multiple copies found on search path:")
-        for p in discovered[name][1:]:
+        for p in info["other_locations"]:
             typer.echo(f"   ↳ {p}")
 
-    if verbose:
-
-        def _iter_files(base: Path):
-            if verbose == 1:
-                yield from sorted(f.name for f in base.iterdir() if f.is_file())
-            else:  # verbose ≥ 2 ⇒ recursive
-                for fp in base.rglob("*"):
-                    if fp.is_file():
-                        yield fp.relative_to(base)
-
+    if verbose and info.get("files"):
         typer.echo("\nFiles:")
-        for rel in _iter_files(primary_path):
+        for rel in info["files"]:
             typer.echo(f" • {rel}")
 
 
@@ -169,64 +134,25 @@ def add_template_set(
     * **Wheel / sdist** → `pip install ./dist/…`
     * **Directory** → `pip install (-e) <dir>`  (use *-e/--editable* to develop)
     """
-    src_path = Path(from_bundle) if from_bundle else Path(source)
-    is_local = src_path.exists()
-
-    # ------------------------------------------------------------------ helpers
-    def _build_installer(use_editable: bool) -> List[str]:
-        """
-        Prefer **uv** if it is on PATH; fall back to stdlib pip.
-        """
-        import shutil
-
-        if shutil.which("uv"):
-            base = ["uv", "pip", "install"]
-        else:
-            base = [sys.executable, "-m", "pip", "install"]
-
-        base += ["--no-deps"]
-        if force:
-            base += ["--upgrade", "--force-reinstall"]
-        if use_editable:
-            base += ["-e"]
-        return base
-
-    # ----------------------------------------------------------------- resolve
-    if is_local:
-        # directory OR file
-        if src_path.is_dir():
-            pip_cmd = _build_installer(editable)
-            pip_cmd.append(str(src_path.resolve()))
-        else:  # file (wheel / sdist)
-            pip_cmd = _build_installer(False)
-            pip_cmd.append(str(src_path.resolve()))
-    else:
-        # assume a PyPI project slug
-        pip_cmd = _build_installer(False)
-        pip_cmd.append(source)
-
-    # ------------------------------------------------------------ install step
     typer.echo("⏳  Installing via pip …")
-    sets_before = set(_discover_template_sets().keys())
-
     try:
-        subprocess.run(
-            pip_cmd,
-            check=True,
-            text=True,
-            stdout=None if verbose else subprocess.PIPE,
-            stderr=None if verbose else subprocess.STDOUT,
+        result = _run_handler(
+            {
+                "operation": "add",
+                "source": source,
+                "from_bundle": from_bundle,
+                "editable": editable,
+                "force": force,
+                "verbose": verbose,
+            }
         )
-    except subprocess.CalledProcessError as exc:
+    except Exception as exc:  # noqa: BLE001
         typer.echo("❌  Installation failed.")
-        if not verbose and exc.stdout:
-            typer.echo(exc.stdout)
-        raise typer.Exit(code=exc.returncode)
+        if not verbose:
+            typer.echo(str(exc))
+        raise typer.Exit(code=1)
 
-    # --------------------------------------------------------------- feedback
-    sets_after = set(_discover_template_sets().keys())
-    new_sets = sorted(sets_after - sets_before)
-
+    new_sets = result.get("installed", [])
     if new_sets:
         typer.echo(
             f"✅  Installed template-set{'s' if len(new_sets) > 1 else ''}: "
@@ -258,77 +184,22 @@ def remove_template_set(
         help="Show pip/uv output.",
     ),
 ):
-    """
-    Uninstall the wheel / editable project that exposes *SET_NAME* in the
-    ``peagen.template_sets`` entry-point group.
-    """
-    # ---------------------------------------------------------------- find dist(s)
-    dists: list[str] = []
-    for dist in im.distributions():
-        if any(
-            ep.group == "peagen.template_sets" and ep.name == name
-            for ep in dist.entry_points
-        ):
-            dists.append(dist.metadata["Name"])
-
-    if not dists:
-        typer.echo(f"❌  Template-set '{name}' not found (nothing to remove).")
-        raise typer.Exit(code=1)
-
-    # ---------------------------------------------------------------- protect core
-    PROTECTED_DISTS = {"peagen"}  # core wheel(s)
-    protected = [d for d in dists if d.lower() in PROTECTED_DISTS]
-    removable = [d for d in dists if d.lower() not in PROTECTED_DISTS]
-
-    if protected and not removable:
-        typer.echo(
-            "⚠️  The requested template-set is bundled with Peagen itself and "
-            "cannot be uninstalled."
-        )
-        raise typer.Exit(code=1)
-
-    if protected and removable:
-        typer.echo(
-            "⚠️  Skipping core distribution(s) "
-            + ", ".join(protected)
-            + "; proceeding to uninstall "
-            + ", ".join(removable)
-        )
-        dists = removable
-
-    # ---------------------------------------------------------------- confirm
+    """Uninstall the wheel/editable project that exposes ``SET_NAME``."""
     if not yes:
-        if not typer.confirm(f"Uninstall distribution(s): {', '.join(dists)} ?"):
+        if not typer.confirm(f"Uninstall template-set '{name}' ?"):
             typer.echo("Aborted.")
             raise typer.Exit()
 
-    # ---------------------------------------------------------------- build cmd
-    if shutil.which("uv"):
-        # uv’s pip clone does not need/allow -y (non-interactive by default)
-        cmd = ["uv", "pip", "uninstall"] + dists
-    else:
-        cmd = [sys.executable, "-m", "pip", "uninstall", "-y"] + dists
-
-    # ---------------------------------------------------------------- run uninstall
     typer.echo("⏳  Uninstalling via pip …")
     try:
-        subprocess.run(
-            cmd,
-            check=True,
-            text=True,
-            stdout=None if verbose else subprocess.PIPE,
-            stderr=None if verbose else subprocess.STDOUT,
-        )
-    except subprocess.CalledProcessError as exc:
-        typer.echo("❌  Uninstall failed.")
-        if not verbose and exc.stdout:
-            typer.echo(exc.stdout)
-        raise typer.Exit(code=exc.returncode)
+        result = _run_handler({"operation": "remove", "name": name, "verbose": verbose})
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"❌  {exc}")
+        raise typer.Exit(code=1)
 
-    # ---------------------------------------------------------------- verify
-    if name in _discover_template_sets():
+    if result.get("removed"):
+        typer.echo(f"✅  Removed template-set '{name}'.")
+    else:
         typer.echo(
             "⚠️  Uninstall completed, but the template-set is still discoverable."
         )
-    else:
-        typer.echo(f"✅  Removed template-set '{name}'.")

--- a/pkgs/standards/peagen/peagen/core/templates_core.py
+++ b/pkgs/standards/peagen/peagen/core/templates_core.py
@@ -1,0 +1,199 @@
+"""
+peagen.core.templates_core
+==========================
+
+Business logic for managing Peagen template sets.
+
+Public API
+----------
+- discover_template_sets()
+- list_template_sets()
+- show_template_set()
+- add_template_set()
+- remove_template_set()
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as im
+from importlib import import_module
+import subprocess
+import shutil
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, List, Optional
+
+import peagen.template_sets as _pt
+from peagen.plugins import registry
+
+
+def _namespace_dirs() -> List[Path]:
+    """Return the search roots that may contain template-set folders."""
+    return [Path(p) for p in _pt.__path__]
+
+
+def discover_template_sets() -> Dict[str, List[Path]]:
+    """Return mapping ``set_name -> [locations...]``."""
+    sets: Dict[str, List[Path]] = {}
+    for ns_root in _namespace_dirs():
+        try:
+            for child in ns_root.iterdir():
+                if child.is_dir():
+                    sets.setdefault(child.name, []).append(child)
+        except PermissionError:
+            continue
+    for name, plugin in registry.get("template_sets", {}).items():
+        mod = plugin if isinstance(plugin, ModuleType) else import_module(plugin.__module__)
+        if hasattr(mod, "__path__"):
+            for root in mod.__path__:
+                sets.setdefault(name, []).append(Path(root))
+        elif hasattr(mod, "__file__"):
+            sets.setdefault(name, []).append(Path(mod.__file__).parent)
+    return sets
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+def list_template_sets(verbose: int = 0) -> Dict[str, Any]:
+    """Return information about all discovered template sets."""
+    discovered = discover_template_sets()
+    result = {"total": len(discovered), "sets": []}
+    for name, paths in sorted(discovered.items()):
+        entry: Dict[str, Any] = {"name": name}
+        if verbose:
+            entry["paths"] = [str(p) for p in paths]
+        result["sets"].append(entry)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Show
+# ---------------------------------------------------------------------------
+
+def show_template_set(name: str, verbose: int = 0) -> Dict[str, Any]:
+    """Return detailed info for one template set."""
+    discovered = discover_template_sets()
+    if name not in discovered:
+        raise ValueError(f"Template-set '{name}' not found")
+
+    primary = discovered[name][0]
+    info: Dict[str, Any] = {"name": name, "location": str(primary)}
+    if len(discovered[name]) > 1:
+        info["other_locations"] = [str(p) for p in discovered[name][1:]]
+
+    if verbose:
+        def _iter_files(base: Path):
+            if verbose == 1:
+                yield from sorted(f.name for f in base.iterdir() if f.is_file())
+            else:
+                for fp in base.rglob("*"):
+                    if fp.is_file():
+                        yield str(fp.relative_to(base))
+        info["files"] = list(_iter_files(primary))
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Add
+# ---------------------------------------------------------------------------
+
+def add_template_set(
+    source: str,
+    *,
+    from_bundle: Optional[str] = None,
+    editable: bool = False,
+    force: bool = False,
+    verbose: bool = False,
+) -> Dict[str, Any]:
+    """Install a template-set distribution."""
+    src_path = Path(from_bundle) if from_bundle else Path(source)
+    is_local = src_path.exists()
+
+    def _build_installer(use_editable: bool) -> List[str]:
+        if shutil.which("uv"):
+            base = ["uv", "pip", "install"]
+        else:
+            base = [sys.executable, "-m", "pip", "install"]
+        base += ["--no-deps"]
+        if force:
+            base += ["--upgrade", "--force-reinstall"]
+        if use_editable:
+            base += ["-e"]
+        return base
+
+    if is_local:
+        if src_path.is_dir():
+            pip_cmd = _build_installer(editable)
+            pip_cmd.append(str(src_path.resolve()))
+        else:
+            pip_cmd = _build_installer(False)
+            pip_cmd.append(str(src_path.resolve()))
+    else:
+        pip_cmd = _build_installer(False)
+        pip_cmd.append(source)
+
+    sets_before = set(discover_template_sets().keys())
+    try:
+        subprocess.run(
+            pip_cmd,
+            check=True,
+            text=True,
+            stdout=None if verbose else subprocess.PIPE,
+            stderr=None if verbose else subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(exc.stdout or "installation failed") from exc
+
+    sets_after = set(discover_template_sets().keys())
+    new_sets = sorted(sets_after - sets_before)
+    return {"installed": new_sets}
+
+
+# ---------------------------------------------------------------------------
+# Remove
+# ---------------------------------------------------------------------------
+
+def remove_template_set(
+    name: str,
+    *,
+    verbose: bool = False,
+) -> Dict[str, Any]:
+    """Uninstall the package that exposes *name* as a template-set."""
+    dists: List[str] = []
+    for dist in im.distributions():
+        if any(
+            ep.group == "peagen.template_sets" and ep.name == name
+            for ep in dist.entry_points
+        ):
+            dists.append(dist.metadata["Name"])
+
+    if not dists:
+        raise ValueError(f"Template-set '{name}' not found")
+
+    PROTECTED_DISTS = {"peagen"}
+    removable = [d for d in dists if d.lower() not in PROTECTED_DISTS]
+    if not removable:
+        raise ValueError("Cannot uninstall bundled template-set")
+    dists = removable
+
+    if shutil.which("uv"):
+        cmd = ["uv", "pip", "uninstall"] + dists
+    else:
+        cmd = [sys.executable, "-m", "pip", "uninstall", "-y"] + dists
+
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            text=True,
+            stdout=None if verbose else subprocess.PIPE,
+            stderr=None if verbose else subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(exc.stdout or "uninstall failed") from exc
+
+    remaining = discover_template_sets()
+    return {"removed": name not in remaining, "dists": dists}

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -1,0 +1,44 @@
+"""peagen.handlers.templates_handler
+----------------------------------
+
+Async handler for template-set management tasks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from peagen.core.templates_core import (
+    list_template_sets,
+    show_template_set,
+    add_template_set,
+    remove_template_set,
+)
+from peagen.models.schemas import Task  # type: ignore
+
+
+async def templates_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
+    """Dispatch template-set operations based on ``args.operation``."""
+    payload = task.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
+    op = args.get("operation")
+
+    if op == "list":
+        return list_template_sets(verbose=int(args.get("verbose", 0)))
+    if op == "show":
+        return show_template_set(args["name"], verbose=int(args.get("verbose", 0)))
+    if op == "add":
+        return add_template_set(
+            args["source"],
+            from_bundle=args.get("from_bundle"),
+            editable=args.get("editable", False),
+            force=args.get("force", False),
+            verbose=args.get("verbose", False),
+        )
+    if op == "remove":
+        return remove_template_set(
+            args["name"],
+            verbose=args.get("verbose", False),
+        )
+
+    raise ValueError(f"Unknown operation: {op}")


### PR DESCRIPTION
## Summary
- move template set logic into `templates_core`
- add async `templates_handler`
- call `templates_handler` from templates CLI commands

## Testing
- `ruff format pkgs/standards/peagen/peagen/cli/commands/templates.py`
- `ruff check pkgs/standards/peagen/peagen/cli/commands/templates.py`
- `pytest -q` *(fails: 559 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_684055b59bb08331acc553f6d68596b8