### PR TITLE
Add database migration command

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -231,6 +231,14 @@ For reference implementations, see the sample specs under
 and evaluator-pool variations.
 
 
+### `peagen db upgrade`
+
+Run Alembic migrations to the latest version.
+
+```bash
+peagen db upgrade
+```
+
 ---
 
 ## Examples & Walkthroughs

--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -19,6 +19,7 @@ from .commands import (
     local_eval_app,
     local_extras_app,
     local_fetch_app,
+    local_db_app,
     local_init_app,
     local_process_app,
     local_mutate_app,
@@ -144,6 +145,7 @@ local_app.add_typer(local_doe_app,)
 local_app.add_typer(local_eval_app,)
 local_app.add_typer(local_extras_app, name="extras-schemas")
 local_app.add_typer(local_fetch_app,)
+local_app.add_typer(local_db_app, name="db")
 local_app.add_typer(local_init_app,          name="init")
 local_app.add_typer(local_process_app)
 local_app.add_typer(local_mutate_app)

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -4,6 +4,7 @@ from .doe import local_doe_app, remote_doe_app
 from .eval import local_eval_app, remote_eval_app
 from .extras import local_extras_app, remote_extras_app
 from .fetch import local_fetch_app, remote_fetch_app
+from .db import local_db_app
 from .init import local_init_app, remote_init_app
 from .process import local_process_app, remote_process_app
 from .mutate import local_mutate_app, remote_mutate_app
@@ -23,6 +24,7 @@ __all__ = [
     "remote_extras_app",
     "local_fetch_app",
     "remote_fetch_app",
+    "local_db_app",
     "local_init_app",
     "remote_init_app",
     "local_process_app",
@@ -35,4 +37,3 @@ __all__ = [
     "local_validate_app",
     "remote_validate_app",
 ]
-

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -1,0 +1,17 @@
+
+"""Database management commands."""
+
+from __future__ import annotations
+
+import subprocess
+
+import typer
+
+local_db_app = typer.Typer(help="Database utilities.")
+
+
+@local_db_app.command("upgrade")
+def upgrade() -> None:
+    """Apply Alembic migrations up to HEAD."""
+    typer.echo("Running alembic upgrade head …")
+    subprocess.run(["alembic", "upgrade", "head"], check=True)


### PR DESCRIPTION
## Summary
- add `db` command with `upgrade` subcommand to run alembic migrations
- expose `local_db_app` in command registry
- wire `peagen db` into the main CLI
- document the new command in README

## Testing
- `pytest -q` *(fails: `/usr/bin/pytest: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_6847380093c48331a81204578494ff9c