### PR TITLE
Add DB migrations step for Peagen images

### DIFF
--- a/infra/Dockerfile.gw
+++ b/infra/Dockerfile.gw
@@ -16,6 +16,8 @@ WORKDIR /app
 # 1. Copy only dependency-defining files first (better layer caching)
 COPY ./pkgs/ ./pkgs/
 COPY ./infra/.gw.peagen.toml ./.peagen.toml
+COPY ./alembic.ini ./alembic.ini
+COPY ./migrations ./migrations
 
 RUN uv pip install --directory pkgs/standards/peagen --system .
 
@@ -33,9 +35,4 @@ ENV \
     MINIO_USER="" \
     MINIO_ROOT_PASSWORD=""
     
-CMD ["python", "-c", "\
-import uvicorn; \
-uvicorn.run('peagen.gateway:app', \
-            host='0.0.0.0', \
-            port=8000, \
-            log_level='info')"]
+CMD ["sh", "-c", "alembic upgrade head && python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]

--- a/infra/Dockerfile.worker
+++ b/infra/Dockerfile.worker
@@ -16,6 +16,8 @@ WORKDIR /app
 # 1. Copy only dependency-defining files first (better layer caching)
 COPY ./pkgs/ ./pkgs/
 COPY ./infra/.worker.peagen.toml ./.peagen.toml
+COPY ./alembic.ini ./alembic.ini
+COPY ./migrations ./migrations
 
 RUN uv pip install --directory pkgs/standards/peagen --system .
 
@@ -27,9 +29,4 @@ ENV \
     DQ_GATEWAY=""\
     PORT="8001"
 
-CMD ["python", "-c", "\
-import uvicorn; \
-uvicorn.run('peagen.worker:app', \
-            host='0.0.0.0', \
-            port=8001, \
-            log_level='info')"]
+CMD ["sh", "-c", "alembic upgrade head && python -c 'import uvicorn; uvicorn.run(\"peagen.worker:app\", host=\"0.0.0.0\", port=8001, log_level=\"info\")'"]


### PR DESCRIPTION
## Summary
- run `alembic upgrade head` before starting gateway and worker containers
- bundle alembic config and migration files into Docker images

## Testing
- `python scripts/run_all_tests.py core` *(fails: unrecognized arguments: --cov=.)*

------
https://chatgpt.com/codex/tasks/task_b_6847380ce6708331b0487c10bffdbb89