### PR TITLE
Add revision/downgrade commands

### DIFF
--- a/pkgs/standards/peagen/migrations/versions/a2c8e35c9e56_init.py
+++ b/pkgs/standards/peagen/migrations/versions/a2c8e35c9e56_init.py
@@ -1,0 +1,28 @@
+"""init
+
+Revision ID: a2c8e35c9e56
+Revises: 83262a8eda95
+Create Date: 2025-06-10 00:13:18.489932
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a2c8e35c9e56'
+down_revision: Union[str, None] = '83262a8eda95'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -13,5 +13,62 @@ local_db_app = typer.Typer(help="Database utilities.")
 @local_db_app.command("upgrade")
 def upgrade() -> None:
     """Apply Alembic migrations up to HEAD."""
-    typer.echo("Running alembic upgrade head …")
-    subprocess.run(["alembic", "upgrade", "head"], check=True)
+    typer.echo(
+        "Running alembic -c pkgs/standards/peagen/alembic.ini upgrade head …"
+    )
+    subprocess.run(
+        [
+            "alembic",
+            "-c",
+            "pkgs/standards/peagen/alembic.ini",
+            "upgrade",
+            "head",
+        ],
+        check=True,
+    )
+
+
+@local_db_app.command("revision")
+def revision() -> None:
+    """Generate a new Alembic revision."""
+    typer.echo(
+        "Running alembic -c pkgs/standards/peagen/alembic.ini revision --autogenerate -m 'init' …"
+    )
+    try:
+        subprocess.run(
+            [
+                "alembic",
+                "-c",
+                "pkgs/standards/peagen/alembic.ini",
+                "revision",
+                "--autogenerate",
+                "-m",
+                "init",
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:  # noqa: BLE001
+        typer.echo(f"[ERROR] {exc}")
+        raise typer.Exit(1)
+
+
+@local_db_app.command("downgrade")
+def downgrade() -> None:
+    """Downgrade the database by one revision."""
+    typer.echo(
+        "Running alembic -c pkgs/standards/peagen/alembic.ini downgrade -1 …"
+    )
+    try:
+        subprocess.run(
+            [
+                "alembic",
+                "-c",
+                "pkgs/standards/peagen/alembic.ini",
+                "downgrade",
+                "-1",
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:  # noqa: BLE001
+        typer.echo(f"[ERROR] {exc}")
+        raise typer.Exit(1)


### PR DESCRIPTION
## Summary
- add `revision` and `downgrade` commands to Peagen CLI `db` module
- update `upgrade` command to use project Alembic config
- add migration stub `a2c8e35c9e56_init.py`

## Testing
- `pytest pkgs/standards/peagen/tests/unit/test_alembic_integration.py::test_alembic_upgrade_and_current -q`

------
https://chatgpt.com/codex/tasks/task_b_68476d33b66c8331a624ce032700c80d