### PR TITLE
Add alembic migration task modules

### DIFF
--- a/pkgs/standards/peagen/peagen/core/migrate_core.py
+++ b/pkgs/standards/peagen/peagen/core/migrate_core.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+
+ALEMBIC_CFG = Path(__file__).resolve().parents[3] / "alembic.ini"
+
+
+def alembic_upgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
+    """Apply migrations up to HEAD using *cfg*."""
+    try:
+        subprocess.run([
+            "alembic",
+            "-c",
+            str(cfg),
+            "upgrade",
+            "head",
+        ], check=True)
+    except subprocess.CalledProcessError as exc:  # noqa: BLE001
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True}
+
+
+def alembic_downgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
+    """Downgrade the database by one revision using *cfg*."""
+    try:
+        subprocess.run([
+            "alembic",
+            "-c",
+            str(cfg),
+            "downgrade",
+            "-1",
+        ], check=True)
+    except subprocess.CalledProcessError as exc:  # noqa: BLE001
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True}
+
+
+def alembic_revision(message: str, cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
+    """Create a new revision with *message* using *cfg*."""
+    try:
+        subprocess.run([
+            "alembic",
+            "-c",
+            str(cfg),
+            "revision",
+            "--autogenerate",
+            "-m",
+            message,
+        ], check=True)
+    except subprocess.CalledProcessError as exc:  # noqa: BLE001
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True}

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from peagen.core.migrate_core import (
+    ALEMBIC_CFG,
+    alembic_downgrade,
+    alembic_revision,
+    alembic_upgrade,
+)
+from peagen.models import Task
+
+
+async def migrate_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
+    if not isinstance(task_or_dict, dict):
+        task_dict: Dict[str, Any] = json.loads(task_or_dict.model_dump_json())
+    else:
+        task_dict = task_or_dict
+
+    args: Dict[str, Any] = task_dict["payload"]["args"]
+    op: str = args["op"]
+    cfg_path_str: str | None = args.get("alembic_ini")
+    cfg_path = Path(cfg_path_str).expanduser() if cfg_path_str else ALEMBIC_CFG
+
+    if op == "upgrade":
+        return alembic_upgrade(cfg_path)
+    if op == "downgrade":
+        return alembic_downgrade(cfg_path)
+    if op == "revision":
+        msg = args.get("message", "init")
+        return alembic_revision(msg, cfg_path)
+    return {"ok": False, "error": f"unknown op: {op}"}

--- a/pkgs/standards/peagen/tests/unit/test_migrate_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_migrate_core.py
@@ -1,0 +1,44 @@
+import pytest
+from pathlib import Path
+
+from peagen.core import migrate_core
+
+
+@pytest.mark.unit
+def test_alembic_upgrade_invokes_subprocess(monkeypatch, tmp_path: Path):
+    calls = {}
+
+    def fake_run(cmd, check):
+        calls["cmd"] = cmd
+
+    monkeypatch.setattr(migrate_core.subprocess, "run", fake_run)
+
+    cfg = tmp_path / "al.ini"
+    result = migrate_core.alembic_upgrade(cfg)
+
+    assert result == {"ok": True}
+    assert calls["cmd"] == ["alembic", "-c", str(cfg), "upgrade", "head"]
+
+
+@pytest.mark.unit
+def test_alembic_revision_invokes_subprocess(monkeypatch, tmp_path: Path):
+    calls = {}
+
+    def fake_run(cmd, check):
+        calls["cmd"] = cmd
+
+    monkeypatch.setattr(migrate_core.subprocess, "run", fake_run)
+
+    cfg = tmp_path / "al.ini"
+    result = migrate_core.alembic_revision("msg", cfg)
+
+    assert result == {"ok": True}
+    assert calls["cmd"] == [
+        "alembic",
+        "-c",
+        str(cfg),
+        "revision",
+        "--autogenerate",
+        "-m",
+        "msg",
+    ]

--- a/pkgs/standards/peagen/tests/unit/test_migrate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_migrate_handler.py
@@ -1,0 +1,29 @@
+import asyncio
+import pytest
+from pathlib import Path
+
+from peagen.handlers import migrate_handler as handler
+from peagen.models import Task
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("as_dict", [True, False])
+def test_migrate_handler_dispatch(monkeypatch, as_dict):
+    captured = {}
+
+    def fake_upgrade(cfg):
+        captured["op"] = "upgrade"
+        captured["cfg"] = cfg
+        return {"ok": True}
+
+    monkeypatch.setattr(handler, "alembic_upgrade", fake_upgrade)
+
+    args = {"op": "upgrade", "alembic_ini": "~/a.ini"}
+    task = {"payload": {"args": args}}
+    if not as_dict:
+        task = Task(pool="p", payload=task["payload"])
+
+    result = asyncio.run(handler.migrate_handler(task))
+
+    assert result == {"ok": True}
+    assert captured["cfg"] == Path("~/a.ini").expanduser()


### PR DESCRIPTION
## Summary
- add reusable migration core with upgrade/downgrade/revision helpers
- implement async handler that dispatches to the core
- update `db` CLI to call the handler via a task
- add unit tests for the new core and handler

## Testing
- `pytest pkgs/standards/peagen/tests/unit/test_migrate_core.py pkgs/standards/peagen/tests/unit/test_migrate_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6847ef0676f8833185a2f70415a2f139