### PR TITLE
Implement clipboard features in dashboard

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_tui_clipboard.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_clipboard.py
@@ -1,0 +1,101 @@
+import pytest
+from peagen.tui import app as tui_app
+from peagen.tui.app import QueueDashboardApp
+
+
+class DummyTable:
+    cursor_row = 0
+    cursor_column = 0
+
+    def get_cell_at(self, row, col):
+        assert (row, col) == (0, 0)
+        return "cell"
+
+
+def make_property(value):
+    return property(lambda self: value)
+
+
+@pytest.mark.unit
+def test_action_copy_id_datatable(monkeypatch):
+    captured = {}
+
+    def fake_copy(text):
+        captured["text"] = text
+
+    monkeypatch.setattr(tui_app, "clipboard_copy", fake_copy)
+    table = DummyTable()
+    monkeypatch.setattr(QueueDashboardApp, "focused", make_property(table))
+
+    app = QueueDashboardApp()
+    app.action_copy_id()
+
+    assert captured["text"] == "cell"
+
+
+@pytest.mark.unit
+def test_action_copy_id_input(monkeypatch):
+    captured = {}
+
+    def fake_copy(text):
+        captured["text"] = text
+
+    monkeypatch.setattr(tui_app, "clipboard_copy", fake_copy)
+
+    class DummyInput:
+        selected_text = "sel"
+        value = "val"
+
+    dummy = DummyInput()
+    monkeypatch.setattr(QueueDashboardApp, "focused", make_property(dummy))
+
+    app = QueueDashboardApp()
+    app.action_copy_id()
+
+    assert captured["text"] == "sel"
+
+
+@pytest.mark.unit
+def test_action_paste_clipboard_input(monkeypatch):
+    def fake_paste():
+        return "stuff"
+
+    monkeypatch.setattr(tui_app, "clipboard_paste", fake_paste)
+
+    class DummyInput:
+        def __init__(self):
+            self.inserted = None
+
+        def insert_text_at_cursor(self, text):
+            self.inserted = text
+
+    dummy = DummyInput()
+    monkeypatch.setattr(QueueDashboardApp, "focused", make_property(dummy))
+
+    app = QueueDashboardApp()
+    app.action_paste_clipboard()
+
+    assert dummy.inserted == "stuff"
+
+
+@pytest.mark.unit
+def test_action_paste_clipboard_textarea(monkeypatch):
+    def fake_paste():
+        return "more"
+
+    monkeypatch.setattr(tui_app, "clipboard_paste", fake_paste)
+
+    class DummyTA:
+        def __init__(self):
+            self.inserted = None
+
+        def insert(self, text):
+            self.inserted = text
+
+    dummy = DummyTA()
+    monkeypatch.setattr(QueueDashboardApp, "focused", make_property(dummy))
+
+    app = QueueDashboardApp()
+    app.action_paste_clipboard()
+
+    assert dummy.inserted == "more"


### PR DESCRIPTION
## Summary
- implement OS clipboard helpers in the dashboard
- bind `ctrl+p` to paste from clipboard
- add copy & paste actions for table cells and text widgets
- test dashboard clipboard helpers

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jaml')*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: File not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: No such option: --watch)*

------
https://chatgpt.com/codex/tasks/task_b_684ab6893e10833184f53adb73748e37