### PR TITLE
Add task detail screen for dashboard

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/components/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/components/__init__.py
@@ -7,6 +7,7 @@ from .metrics_tab import MetricsTab
 from .workers_view import WorkersView
 from .templates_view import TemplatesView
 from .reconnect_screen import ReconnectScreen
+from .task_detail_screen import TaskDetailScreen
 
 __all__ = [
     "DashboardFooter",
@@ -16,5 +17,6 @@ __all__ = [
     "WorkersView",
     "TemplatesView",
     "ReconnectScreen",
+    "TaskDetailScreen",
 ]
 

--- a/pkgs/standards/peagen/peagen/tui/components/task_detail_screen.py
+++ b/pkgs/standards/peagen/peagen/tui/components/task_detail_screen.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from textual.app import ComposeResult
+from textual.containers import Center, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+
+class TaskDetailScreen(ModalScreen[None]):
+    """Display details of a selected task."""
+
+    def __init__(self, task: dict) -> None:
+        super().__init__()
+        self.task = task
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - ui code
+        yield Center(
+            Vertical(
+                Static(json.dumps(self.task, indent=2), id="task-json"),
+                Button("Close", id="close"),
+                id="task-detail-box",
+            )
+        )
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:  # pragma: no cover - ui code
+        if event.button.id == "close":
+            await self.dismiss()

--- a/pkgs/standards/peagen/tests/unit/test_tui_task_details.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_task_details.py
@@ -1,0 +1,80 @@
+import pytest
+from textual.coordinate import Coordinate
+
+from peagen.tui.app import QueueDashboardApp
+
+
+class DummyScreen:
+    def __init__(self, task):
+        self.task = task
+
+
+class DummyTable:
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+
+    def get_row_at(self, row):  # old API path
+        class Row:
+            key = self.key
+        return Row()
+
+    def get_cell_at(self, row, col):
+        return self.value
+
+
+class DummyEvent:
+    def __init__(self, table, value):
+        self.data_table = table
+        self.value = value
+        self.coordinate = Coordinate(0, 0)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_click_task_row_opens_detail(monkeypatch):
+    app = QueueDashboardApp()
+    app.backend.tasks = [{"id": "42"}]
+    app.tasks_table = DummyTable("42", "42")
+    app.err_table = DummyTable("x", "x")
+
+    monkeypatch.setattr("peagen.tui.app.TaskDetailScreen", DummyScreen)
+
+    captured = {}
+
+    async def fake_push(screen):
+        captured["screen"] = screen
+
+    monkeypatch.setattr(app, "push_screen", fake_push)
+
+    event = DummyEvent(app.tasks_table, "42")
+
+    await app.on_data_table_cell_selected(event)
+
+    assert isinstance(captured.get("screen"), DummyScreen)
+    assert captured["screen"].task["id"] == "42"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_click_error_row_opens_detail(monkeypatch):
+    app = QueueDashboardApp()
+    app.backend.tasks = [{"id": "99"}]
+    app.err_table = DummyTable("99", "99")
+    app.tasks_table = DummyTable("y", "y")
+
+    monkeypatch.setattr("peagen.tui.app.TaskDetailScreen", DummyScreen)
+
+    captured = {}
+
+    async def fake_push(screen):
+        captured["screen"] = screen
+
+    monkeypatch.setattr(app, "push_screen", fake_push)
+
+    event = DummyEvent(app.err_table, "99")
+
+    await app.on_data_table_cell_selected(event)
+
+    assert isinstance(captured.get("screen"), DummyScreen)
+    assert captured["screen"].task["id"] == "99"


### PR DESCRIPTION
## Summary
- add new TaskDetailScreen component for viewing task JSON
- export TaskDetailScreen
- add open_task_detail method in QueueDashboardApp and hook up row selection
- tests for selecting rows opening task details

## Testing
- `ruff check`
- `pytest -q pkgs/standards/peagen/tests/unit/test_tui_task_details.py`
- `pytest -q` *(fails: 287 errors during collection)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: file not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: no such option)*

------
https://chatgpt.com/codex/tasks/task_b_684ac1bf2e2483319738ebc4a34f73eb