### PR TITLE
Add FilterBar widget for task filters

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/components/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/components/__init__.py
@@ -8,6 +8,7 @@ from .workers_view import WorkersView
 from .templates_view import TemplatesView
 from .reconnect_screen import ReconnectScreen
 from .task_detail_screen import TaskDetailScreen
+from .filter_bar import FilterBar
 
 __all__ = [
     "DashboardFooter",
@@ -18,5 +19,6 @@ __all__ = [
     "TemplatesView",
     "ReconnectScreen",
     "TaskDetailScreen",
+    "FilterBar",
 ]
 

--- a/pkgs/standards/peagen/peagen/tui/components/filter_bar.py
+++ b/pkgs/standards/peagen/peagen/tui/components/filter_bar.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Select
+
+
+class FilterBar(Horizontal):
+    """Dropdown filters for the dashboard."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.id_select = Select(prompt="id", allow_blank=True, id="filter_id", compact=True)
+        self.pool_select = Select(prompt="pool", allow_blank=True, id="filter_pool", compact=True)
+        self.status_select = Select(prompt="status", allow_blank=True, id="filter_status", compact=True)
+        self.action_select = Select(prompt="action", allow_blank=True, id="filter_action", compact=True)
+        self.label_select = Select(prompt="label", allow_blank=True, id="filter_label", compact=True)
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - UI layout
+        yield self.id_select
+        yield self.pool_select
+        yield self.status_select
+        yield self.action_select
+        yield self.label_select
+
+    def _set_options(self, select: Select, values: Iterable[str]) -> None:
+        current = select.value
+        select.set_options([(v, v) for v in sorted(values)])
+        if current in {v for _, v in select._options}:  # type: ignore[attr-defined]
+            select.value = current
+
+    def update_options(self, tasks: Iterable[dict]) -> None:
+        """Rebuild dropdown options from ``tasks``."""
+        ids = {str(t.get("id")) for t in tasks if t.get("id") is not None}
+        pools = {t.get("pool") for t in tasks if t.get("pool")}
+        statuses = {t.get("status") for t in tasks if t.get("status")}
+        actions = {t.get("payload", {}).get("action") for t in tasks if t.get("payload", {}).get("action")}
+        labels = {lbl for t in tasks for lbl in t.get("labels", [])}
+        self._set_options(self.id_select, ids)
+        self._set_options(self.pool_select, pools)
+        self._set_options(self.status_select, statuses)
+        self._set_options(self.action_select, actions)
+        self._set_options(self.label_select, labels)
+
+    def clear(self) -> None:
+        """Clear all dropdown selections."""
+        for select in (
+            self.id_select,
+            self.pool_select,
+            self.status_select,
+            self.action_select,
+            self.label_select,
+        ):
+            select.clear()

--- a/pkgs/standards/peagen/peagen/tui/components/footer.py
+++ b/pkgs/standards/peagen/peagen/tui/components/footer.py
@@ -11,7 +11,7 @@ from textual.widgets import Footer
 class DashboardFooter(Footer):
     clock: reactive[str] = reactive("")
     metrics: reactive[str] = reactive("")
-    hint: str = "Tab: switch | S: sort | F: filter | C: collapse | Esc: clear"
+    hint: str = "Tab: switch | S: sort | C: collapse | Esc: clear"
 
     def on_mount(self) -> None:
         self.set_interval(1.0, self.update_metrics)

--- a/pkgs/standards/peagen/tests/unit/test_tui_task_details.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_task_details.py
@@ -78,3 +78,31 @@ async def test_click_error_row_opens_detail(monkeypatch):
 
     assert isinstance(captured.get("screen"), DummyScreen)
     assert captured["screen"].task["id"] == "99"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "select_id,attr,value",
+    [
+        ("filter_id", "filter_id", "42"),
+        ("filter_pool", "filter_pool", "default"),
+        ("filter_status", "filter_status", "done"),
+        ("filter_action", "filter_action", "process"),
+        ("filter_label", "filter_label", "foo"),
+    ],
+)
+def test_on_select_changed_updates_filters(select_id, attr, value):
+    app = QueueDashboardApp()
+
+    class DummySelect:
+        def __init__(self, sid):
+            self.id = sid
+
+    class DummyChanged:
+        def __init__(self, sid, val):
+            self.select = DummySelect(sid)
+            self.value = val
+
+    event = DummyChanged(select_id, value)
+    app.on_select_changed(event)
+    assert getattr(app, attr) == value


### PR DESCRIPTION
## Summary
- implement new `FilterBar` component with five dropdowns
- integrate `FilterBar` into `QueueDashboardApp`
- update footer hint and remove old filter input
- add tests for dropdown selection handling

## Testing
- `ruff check pkgs/standards/peagen`
- `pytest -q` *(fails: 286 errors)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: file not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: invalid option)*

------
https://chatgpt.com/codex/tasks/task_b_684af4bdc0088331a6a0d2ac79b7d9b1