### PR TITLE
Truncate task IDs in Peagen TUI tables

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -87,6 +87,25 @@ def _format_ts(ts: float | str | None) -> str:
         return str(ts)
 
 
+def _truncate_id(task_id: str, length: int = 4) -> str:
+    """Return a shortened representation of *task_id*.
+
+    If the ID is longer than ``2 * length`` characters, the output keeps the
+    first and last ``length`` characters separated by an ellipsis.
+
+    Args:
+        task_id: The full task identifier string.
+        length: Number of characters to show at both ends.
+
+    Returns:
+        The truncated ID for display.
+    """
+
+    if len(task_id) <= length * 2:
+        return task_id
+    return f"{task_id[:length]}...{task_id[-length:]}"
+
+
 class RemoteBackend:
     def __init__(self, gateway_url: str) -> None:
         self.rpc_url = gateway_url.rstrip("/") + "/rpc"
@@ -415,7 +434,7 @@ class QueueDashboardApp(App):
                     prefix = "- " if task_id not in self.collapsed else "+ "
 
                 self.tasks_table.add_row(
-                    f"{prefix}{task_id}",
+                    f"{prefix}{_truncate_id(task_id)}",
                     t_data.get("pool", ""),
                     t_data.get("status", ""),
                     t_data.get("payload", {}).get("action", ""),
@@ -441,7 +460,7 @@ class QueueDashboardApp(App):
                         )
                         if child_task and str(child_id_str) not in seen_task_ids:
                             self.tasks_table.add_row(
-                                f"  {child_id_str}",
+                                f"  {_truncate_id(str(child_id_str))}",
                                 child_task.get("pool", ""),
                                 child_task.get("status", ""),
                                 child_task.get("payload", {}).get("action", ""),
@@ -479,7 +498,7 @@ class QueueDashboardApp(App):
                     result_data = t_data.get("result", {}) or {}
                     err_msg = result_data.get("error", "")
                     self.err_table.add_row(
-                        task_id,
+                        _truncate_id(task_id),
                         t_data.get("pool", ""),
                         t_data.get("status", ""),
                         t_data.get("payload", {}).get("action", ""),


### PR DESCRIPTION
## Summary
- truncate task IDs when rendering task list entries in the Peagen TUI
- add `_truncate_id` helper for shortening IDs

## Testing
- `ruff check pkgs/standards/peagen`
- `pytest -q pkgs/standards/peagen/tests/unit/test_tui_task_details.py`
- `pytest -q pkgs/standards/peagen/tests/unit` *(fails: ValueError: Redis...)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ConnectError)*
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: TypeCheckError)*

------
https://chatgpt.com/codex/tasks/task_b_684b4cce66408331aa000b9140c25c7d