### PR TITLE
Fix TUI task details ID handling

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -742,14 +742,30 @@ class QueueDashboardApp(App):
         widget = self.focused
         text = ""
         if isinstance(widget, DataTable):
-            row, col = widget.cursor_row, widget.cursor_column
-            if row is not None and col is not None:
-                value = (
-                    widget.get_cell_at(Coordinate(row, col))
-                    if hasattr(widget, "get_cell_at")
-                    else widget.get_cell(row, col)
-                )
-                text = str(value)
+            row = widget.cursor_row
+            key_value = None
+            if row is not None:
+                if hasattr(widget, "ordered_rows"):
+                    try:
+                        key_value = widget.ordered_rows[row].key
+                    except Exception:
+                        key_value = None
+                if key_value is None and hasattr(widget, "get_row_key"):
+                    try:
+                        key_value = widget.get_row_key(row)  # type: ignore[attr-defined]
+                    except Exception:
+                        key_value = None
+            if key_value is not None:
+                text = str(key_value)
+            else:
+                row, col = widget.cursor_row, widget.cursor_column
+                if row is not None and col is not None:
+                    value = (
+                        widget.get_cell_at(Coordinate(row, col))
+                        if hasattr(widget, "get_cell_at")
+                        else widget.get_cell(row, col)
+                    )
+                    text = str(value)
         elif isinstance(widget, TextArea):
             text = widget.selected_text or widget.text
         if text:

--- a/pkgs/standards/peagen/peagen/tui/components/task_table.py
+++ b/pkgs/standards/peagen/peagen/tui/components/task_table.py
@@ -31,11 +31,24 @@ class TaskTable(DataTable):
             return
         row_index = meta["row"]
         row_key = None
-        if hasattr(self, "get_row_key"):
-            row_key = self.get_row_key(row_index)
+
+        if hasattr(self, "ordered_rows"):
+            try:
+                row_key = self.ordered_rows[row_index].key
+            except Exception:
+                row_key = None
+
+        if row_key is None and hasattr(self, "get_row_key"):
+            try:
+                row_key = self.get_row_key(row_index)  # type: ignore[attr-defined]
+            except Exception:
+                row_key = None
         if row_key is None and hasattr(self, "get_row_at"):
-            row_obj = self.get_row_at(row_index)
-            row_key = getattr(row_obj, "key", None)
+            try:
+                row_obj = self.get_row_at(row_index)
+                row_key = getattr(row_obj, "key", None)
+            except Exception:
+                row_key = None
         if row_key is None:
             try:
                 cell_value = self.get_cell_at(Coordinate(row_index, 0))


### PR DESCRIPTION
## Summary
- prevent truncated IDs when double-clicking tasks
- copy the full task ID from the table

## Testing
- `ruff check`
- `pytest -q` *(fails: Redis URL must specify scheme, 287 errors)*

------
https://chatgpt.com/codex/tasks/task_b_684b6b909f688331bed7a8cad9b9bb07