### PR TITLE
Enable stable column sorting in Peagen TUI

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -205,7 +205,30 @@ class QueueDashboardApp(App):
         ("q", "quit", "Quit"),
     ]
 
-    SORT_KEYS = ["time", "pool", "status", "action", "label", "duration"]
+    SORT_KEYS = [
+        "time",
+        "pool",
+        "status",
+        "action",
+        "label",
+        "duration",
+        "id",
+        "started_at",
+        "finished_at",
+        "error",
+    ]
+
+    COLUMN_LABEL_TO_SORT_KEY = {
+        "ID": "id",
+        "Pool": "pool",
+        "Status": "status",
+        "Action": "action",
+        "Labels": "label",
+        "Started": "started_at",
+        "Finished": "finished_at",
+        "Duration": "duration",
+        "Error": "error",
+    }
 
     queue_len = reactive(0)
     done_len = reactive(0)
@@ -218,6 +241,7 @@ class QueueDashboardApp(App):
         self.client = TaskStreamClient(ws_url)
         self.backend = RemoteBackend(gateway_url)
         self.sort_key = "time"
+        self.sort_reverse = False
         self.filter_id: str | None = None
         self.filter_pool: str | None = None
         self.filter_status: str | None = None
@@ -362,6 +386,7 @@ class QueueDashboardApp(App):
             "action": self.filter_action,
             "label": self.filter_label,
             "sort_key": self.sort_key,
+            "sort_reverse": self.sort_reverse,
             "collapsed": self.collapsed.copy(),
         }
         processed_data = self._perform_filtering_and_sorting(
@@ -388,6 +413,7 @@ class QueueDashboardApp(App):
             tasks = [t for t in tasks if criteria["label"] in t.get("labels", [])]
 
         sort_key = criteria.get("sort_key")
+        sort_reverse = criteria.get("sort_reverse", False)
         if sort_key:
 
             def _key_func(task_item):
@@ -403,7 +429,10 @@ class QueueDashboardApp(App):
                     )
                 return task_item.get(sort_key)
 
-            tasks.sort(key=lambda t: (_key_func(t) is None, _key_func(t)))
+            tasks_with_val = [t for t in tasks if _key_func(t) is not None]
+            tasks_without_val = [t for t in tasks if _key_func(t) is None]
+            tasks_with_val.sort(key=_key_func, reverse=sort_reverse)
+            tasks = tasks_with_val + tasks_without_val
 
         current_workers = {}
         source_workers = (
@@ -709,6 +738,7 @@ class QueueDashboardApp(App):
         except ValueError:
             idx = 0
         self.sort_key = self.SORT_KEYS[(idx + 1) % len(self.SORT_KEYS)]
+        self.sort_reverse = False
         self.toast(f"Sorting by {self.sort_key}", duration=1.0)
         self.trigger_data_processing()
 
@@ -842,6 +872,38 @@ class QueueDashboardApp(App):
 
         # Selection events no longer open task details automatically.
         return
+
+    async def on_data_table_header_selected(
+        self, event: DataTable.HeaderSelected
+    ) -> None:
+        """Sort a table when the user clicks a column header."""
+        table = event.control
+        column_key = event.column_key
+
+        reverse = False
+        last_key = getattr(table, "_last_sort_key", None)
+        last_reverse = getattr(table, "_last_sort_reverse", False)
+        if last_key == column_key:
+            reverse = not last_reverse
+
+        table.sort(column_key, reverse=reverse)
+        table._last_sort_key = column_key
+        table._last_sort_reverse = reverse
+
+        label_plain = event.label.plain
+        cleaned_label = (
+            label_plain.replace("▲", "")
+            .replace("▼", "")
+            .replace("⬆", "")
+            .replace("⬇", "")
+            .strip()
+        )
+        sort_key = self.COLUMN_LABEL_TO_SORT_KEY.get(cleaned_label)
+        if sort_key:
+            self.sort_key = sort_key
+        self.sort_reverse = reverse
+        self.trigger_data_processing(debounce=False)
+        event.stop()
 
     async def open_task_detail(self, task_id: str) -> None:
         task = self.client.tasks.get(task_id)


### PR DESCRIPTION
## Summary
- track ascending/descending sort state
- propagate sort order when updating filtered data
- refresh tables after header clicks
- strip arrow glyphs from header labels so status sorting works

## Testing
- `ruff check pkgs/standards/peagen`
- `pytest -q pkgs/standards/peagen/tests` *(fails: Redis dependency missing)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: connection refused)*
- `peagen local process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: name resolution error)*

------
https://chatgpt.com/codex/tasks/task_b_68546076ca5c8331abb0e1b15d2d36d3