### PR TITLE
Update TUI collapse controls

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -219,6 +219,7 @@ class QueueDashboardApp(App):
         ("5", "switch('templates')", "Templates"),
         ("ctrl+s", "save_file", "Save"),
         ("c", "toggle_children", "Collapse"),
+        ("space", "toggle_children", "Collapse"),
         ("ctrl+c", "copy_id", "Copy"),
         ("ctrl+p", "paste_clipboard", "Paste"),
         ("s", "cycle_sort", "Sort"),
@@ -544,6 +545,7 @@ class QueueDashboardApp(App):
                 result_data = t_data.get("result") or {}
                 children_ids = result_data.get("children", [])
                 if children_ids:
+                    # Display '-' when expanded and '+' when collapsed
                     prefix = "- " if task_id not in self.collapsed else "+ "
 
                 self.tasks_table.add_row(


### PR DESCRIPTION
## Summary
- add a spacebar binding for toggling task children
- clarify display logic for collapse/expand icons

## Testing
- `ruff check`
- `pytest pkgs/standards/peagen/tests/unit/test_tui_task_details.py -q`
- `peagen local process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: NameResolutionError)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ConnectError)*

------
https://chatgpt.com/codex/tasks/task_b_685571ec21b48331b6a09713942956f4