### PR TITLE
Update TUI collapse controls

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_tui_task_details.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_task_details.py
@@ -129,3 +129,84 @@ def test_on_select_changed_updates_filters(select_id, attr, value):
     asyncio.run(app.on_select_changed(event))
     assert getattr(app, attr) == value
 
+
+@pytest.mark.unit
+def test_parents_collapsed_by_default():
+    app = QueueDashboardApp()
+    table = SimpleTasksTable()
+    app.tasks_table = table
+
+    parent = {"id": "p1", "result": {"children": ["c1"]}}
+    child = {"id": "c1"}
+
+    processed = {
+        "tasks_to_display": [parent, child],
+        "workers_data": {},
+        "metrics_data": {},
+        "collapsed_state": set(),
+    }
+    app._update_ui_with_processed_data(processed, [parent, child])
+
+    assert "p1" in app.collapsed
+    assert table.row_count == 1
+    assert table.rows[0]["cells"][0].startswith("+")
+
+
+@pytest.mark.unit
+def test_toggle_children_shows_and_hides():
+    app = QueueDashboardApp()
+    table = SimpleTasksTable()
+    app.tasks_table = table
+
+    parent = {"id": "p1", "result": {"children": ["c1"]}}
+    child = {"id": "c1"}
+
+    processed = {
+        "tasks_to_display": [parent, child],
+        "workers_data": {},
+        "metrics_data": {},
+        "collapsed_state": set(),
+    }
+
+    app._update_ui_with_processed_data(processed, [parent, child])
+
+    # Cursor on first row (parent)
+    table.cursor_row = 0
+    app.trigger_data_processing = lambda debounce=True: None
+    app.action_toggle_children()
+    assert "p1" not in app.collapsed
+
+    app._update_ui_with_processed_data(processed, [parent, child])
+
+    assert table.row_count == 2
+    assert table.rows[0]["cells"][0].startswith("-")
+
+
+class SimpleTasksTable:
+    def __init__(self):
+        self.rows = []
+        self.cursor_row = 0
+        self.cursor_column = 0
+        self._coord = Coordinate(0, 0)
+
+    @property
+    def row_count(self):
+        return len(self.rows)
+
+    def clear(self):
+        self.rows.clear()
+
+    def add_row(self, *cells, key=None):
+        self.rows.append({"cells": cells, "key": key})
+
+    def get_row_key(self, row):
+        return self.rows[row]["key"] if row < len(self.rows) else None
+
+    @property
+    def cursor_coordinate(self):
+        return self._coord
+
+    @cursor_coordinate.setter
+    def cursor_coordinate(self, coord):
+        self._coord = coord
+


### PR DESCRIPTION
## Summary
- add a spacebar binding for toggling task children
- collapse new parents by default and track seen parents
- skip rendering child rows when their parent is collapsed
- add regression tests for the collapse/expand logic

## Testing
- `ruff check`
- `pytest pkgs/standards/peagen/tests/unit/test_tui_task_details.py -q`
- `peagen local process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: NameResolutionError)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ConnectError)*

------
https://chatgpt.com/codex/tasks/task_b_685571ec21b48331b6a09713942956f4