### PR TITLE
Default collapse controls for TUI tasks

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_tui_collapse.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_collapse.py
@@ -1,0 +1,27 @@
+import pytest
+
+from peagen.tui.app import QueueDashboardApp
+
+
+class DummyTable:
+    def __init__(self, key):
+        self.key = key
+        self.cursor_row = 0
+
+    def get_row_key(self, row):
+        return self.key
+
+
+@pytest.mark.unit
+def test_default_collapsed(monkeypatch):
+    parent = {"id": "p1", "result": {"children": ["c1"]}}
+    child = {"id": "c1"}
+    app = QueueDashboardApp()
+    app.backend.tasks = [parent, child]
+    app.client.tasks = {}
+    app.tasks_table = DummyTable("p1")
+
+    import asyncio
+    asyncio.run(app.async_process_and_update_data())
+
+    assert "p1" in app.collapsed


### PR DESCRIPTION
## Summary
- collapse parent tasks by default when first seen
- show '+' or '-' prefix depending on collapse state
- add regression test for default collapsed parents

## Testing
- `ruff check`
- `pytest pkgs/standards/peagen/tests/unit/test_tui_task_details.py pkgs/standards/peagen/tests/unit/test_tui_collapse.py -q`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ConnectError)*
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: No such option: --watch)*

------
https://chatgpt.com/codex/tasks/task_b_685571ec21b48331b6a09713942956f4