### PR TITLE
Fix spacebar toggle in peagen TUI

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -760,9 +760,18 @@ class QueueDashboardApp(App):
         row = self.tasks_table.cursor_row
         if row is None:
             return
+        row_key = None
         if hasattr(self.tasks_table, "get_row_key"):
-            row_key = self.tasks_table.get_row_key(row)
-        else:
+            try:
+                row_key = self.tasks_table.get_row_key(row)
+            except Exception:
+                row_key = None
+        if row_key is None and hasattr(self.tasks_table, "_row_locations"):
+            try:
+                row_key = self.tasks_table._row_locations.get_key(row)
+            except Exception:
+                row_key = None
+        if row_key is None:
             row_obj = (
                 self.tasks_table.get_row_at(row)
                 if hasattr(self.tasks_table, "get_row_at")

--- a/pkgs/standards/peagen/tests/unit/test_tui_collapse.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_collapse.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 
 from peagen.tui.app import QueueDashboardApp
 
@@ -7,9 +8,65 @@ class DummyTable:
     def __init__(self, key):
         self.key = key
         self.cursor_row = 0
+        self.cursor_column = 0
+        self.rows: list[tuple[tuple[str, ...], str | None]] = []
 
     def get_row_key(self, row):
         return self.key
+
+    def clear(self):
+        self.rows.clear()
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+    @property
+    def cursor_coordinate(self):
+        return (self.cursor_row, self.cursor_column)
+
+    @cursor_coordinate.setter
+    def cursor_coordinate(self, coord):
+        self.cursor_row, self.cursor_column = coord
+
+    def add_row(self, *values, key=None):
+        self.rows.append((values, key))
+
+
+class DummyTableNoGetRowKey:
+    """Simulate DataTable without ``get_row_key``."""
+
+    def __init__(self):
+        from textual._two_way_dict import TwoWayDict
+
+        self.cursor_row = 0
+        self.cursor_column = 0
+        self.rows: list[tuple[tuple[str, ...], str | None]] = []
+        self._row_locations = TwoWayDict({})
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+    @property
+    def cursor_coordinate(self):
+        return (self.cursor_row, self.cursor_column)
+
+    @cursor_coordinate.setter
+    def cursor_coordinate(self, coord):
+        self.cursor_row, self.cursor_column = coord
+
+    def add_row(self, *values, key=None):
+        index = len(self.rows)
+        self.rows.append((values, key))
+        if key is not None:
+            self._row_locations[key] = index
+
+    def clear(self):
+        from textual._two_way_dict import TwoWayDict
+
+        self.rows.clear()
+        self._row_locations = TwoWayDict({})
 
 
 @pytest.mark.unit
@@ -20,8 +77,42 @@ def test_default_collapsed(monkeypatch):
     app.backend.tasks = [parent, child]
     app.client.tasks = {}
     app.tasks_table = DummyTable("p1")
+    monkeypatch.setattr(app, "call_later", lambda func, *args, **kwargs: func(*args, **kwargs))
+    monkeypatch.setattr(app, "trigger_data_processing", lambda debounce=True: asyncio.run(app.async_process_and_update_data()))
 
-    import asyncio
     asyncio.run(app.async_process_and_update_data())
 
+    assert "p1" in app.collapsed
+
+
+@pytest.mark.unit
+def test_toggle_children_updates_table(monkeypatch):
+    parent = {"id": "p1", "result": {"children": ["c1"]}}
+    child = {"id": "c1"}
+    app = QueueDashboardApp()
+    app.backend.tasks = [parent, child]
+    app.client.tasks = {}
+    app.tasks_table = DummyTableNoGetRowKey()
+    monkeypatch.setattr(app, "call_later", lambda func, *args, **kwargs: func(*args, **kwargs))
+    monkeypatch.setattr(app, "trigger_data_processing", lambda debounce=True: asyncio.run(app.async_process_and_update_data()))
+
+    asyncio.run(app.async_process_and_update_data())
+
+    # Initially collapsed: prefix shows '+'
+    assert app.tasks_table.rows
+    assert app.tasks_table.rows[0][0][0].startswith("+ ")
+    assert "p1" in app.collapsed
+
+    app.action_toggle_children()
+    asyncio.run(app.async_process_and_update_data())
+
+    # Expanded: prefix switches to '-'
+    assert app.tasks_table.rows[0][0][0].startswith("- ")
+    assert "p1" not in app.collapsed
+
+    app.action_toggle_children()
+    asyncio.run(app.async_process_and_update_data())
+
+    # Collapsed again: prefix resets to '+'
+    assert app.tasks_table.rows[0][0][0].startswith("+ ")
     assert "p1" in app.collapsed


### PR DESCRIPTION
## Summary
- ensure DataTable row key detection works without `get_row_key`
- test toggling children state using DataTable without `get_row_key`

## Testing
- `ruff check peagen tests`
- `pytest -q tests/unit/test_tui_collapse.py`

------
https://chatgpt.com/codex/tasks/task_b_68558e4c851c8331a0910bdda97a7520