### PR TITLE
Add Task ID search in peagen TUI

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -19,6 +19,7 @@ from textual.widget import NoMatches
 from textual.widgets import (
     DataTable,
     Header,
+    Input,
     Label,  # Added Label
     Select,
     TabbedContent,
@@ -387,6 +388,19 @@ class QueueDashboardApp(App):
         elif event.control.id == "filter_label":
             if self.filter_label != value:
                 self.filter_label = value
+                filter_changed = True
+
+        if filter_changed:
+            self.trigger_data_processing()
+
+    async def on_input_changed(self, event: Input.Changed) -> None:
+        event.stop()
+        value = event.value.strip() if event.value else None
+        filter_changed = False
+
+        if event.input.id == "filter_id":
+            if self.filter_id != value:
+                self.filter_id = value
                 filter_changed = True
 
         if filter_changed:

--- a/pkgs/standards/peagen/peagen/tui/components/filter_bar.py
+++ b/pkgs/standards/peagen/peagen/tui/components/filter_bar.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Iterable
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal
-from textual.widgets import Select
+from textual.widgets import Input, Select
 
 from peagen.models.schemas import Status
 
@@ -56,7 +56,10 @@ class FilterBar(Horizontal):
                 "allow_blank": definition["allow_blank"]
             }
 
+        self.id_input = Input(placeholder="task id", id="filter_id", compact=True)
+
     def compose(self) -> ComposeResult:
+        yield self.id_input
         yield self.pool_select
         yield self.status_select
         yield self.action_select
@@ -120,3 +123,4 @@ class FilterBar(Horizontal):
         ):
             if self._get_select_allow_blank(select_widget):
                 select_widget.value = Select.BLANK
+        self.id_input.value = ""

--- a/pkgs/standards/peagen/tests/unit/test_tui_task_details.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_task_details.py
@@ -113,9 +113,13 @@ def test_on_select_changed_updates_filters(select_id, attr, value):
         def __init__(self, sid):
             self.id = sid
 
+    class DummyInput:
+        def __init__(self, sid):
+            self.id = sid
+
     class DummyChanged:
-        def __init__(self, sid, val):
-            self.select = DummySelect(sid)
+        def __init__(self, control, val):
+            self._control = control
             self.value = val
 
         def stop(self):
@@ -123,10 +127,19 @@ def test_on_select_changed_updates_filters(select_id, attr, value):
 
         @property
         def control(self):
-            return self.select
+            return self._control
 
-    event = DummyChanged(select_id, value)
+        @property
+        def input(self):
+            return self._control
+
+    control_cls = DummyInput if select_id == "filter_id" else DummySelect
+    control = control_cls(select_id)
+    event = DummyChanged(control, value)
     import asyncio
 
-    asyncio.run(app.on_select_changed(event))
+    if select_id == "filter_id":
+        asyncio.run(app.on_input_changed(event))
+    else:
+        asyncio.run(app.on_select_changed(event))
     assert getattr(app, attr) == value


### PR DESCRIPTION
## Summary
- allow user to filter the task table by Task ID
- add input widget for Task ID search in the filter bar
- adjust TUI tests for new Input event handler

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -m unit -q`


------
https://chatgpt.com/codex/tasks/task_b_68592421fe7c8331942864c077588b6a