### PR TITLE
Implement paginated task table in peagen TUI

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -724,8 +724,12 @@ async def task_get(taskId: str):
 
 
 @rpc.method("Pool.listTasks")
-async def pool_list(poolName: str):
-    ids = await queue.lrange(f"{READY_QUEUE}:{poolName}", 0, -1)
+async def pool_list(poolName: str, limit: int | None = None, offset: int = 0):
+    """Return tasks queued for *poolName* with optional pagination."""
+
+    start = max(offset, 0)
+    end = -1 if limit is None else start + limit - 1
+    ids = await queue.lrange(f"{READY_QUEUE}:{poolName}", start, end)
     tasks = []
     for r in ids:
         t = Task.model_validate_json(r)

--- a/pkgs/standards/peagen/peagen/tui/components/footer.py
+++ b/pkgs/standards/peagen/peagen/tui/components/footer.py
@@ -11,7 +11,7 @@ from textual.widgets import Footer
 class DashboardFooter(Footer):
     clock: reactive[str] = reactive("")
     metrics: reactive[str] = reactive("")
-    hint: str = "Tab: switch | S: sort | C: collapse | Esc: clear"
+    hint: str = "Tab: switch | S: sort | C: collapse | Esc: clear | N/P: page"
 
     def on_mount(self) -> None:
         self.set_interval(1.0, self.update_metrics)

--- a/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
@@ -1,0 +1,16 @@
+import pytest
+
+from peagen.tui.app import QueueDashboardApp
+
+
+@pytest.mark.unit
+def test_pagination_actions():
+    app = QueueDashboardApp()
+    app.limit = 10
+    app.offset = 0
+    app.action_next_page()
+    assert app.offset == 10
+    app.action_prev_page()
+    assert app.offset == 0
+    app.action_prev_page()
+    assert app.offset == 0


### PR DESCRIPTION
## Summary
- add limit/offset params to `Pool.listTasks` RPC
- support pagination in `RemoteBackend` and dashboard app
- show pagination keys in the footer
- implement next/prev page actions
- test pagination actions

## Testing
- `uv run --directory . --package peagen ruff format .`
- `uv run --directory . --package peagen ruff check . --fix`
- `uv run --directory . --package peagen pytest -q` *(fails: subprocess.CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_b_68593813fa948331b973edb94d87d90e