### PR TITLE
Fix jitter in Peagen TUI status dropdown

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/components/filter_bar.py
+++ b/pkgs/standards/peagen/peagen/tui/components/filter_bar.py
@@ -111,10 +111,14 @@ class FilterBar(Horizontal):
             str(lbl) for t in tasks for lbl in t.get("labels", []) if lbl is not None
         }
 
-        self._set_options(self.pool_select, pools)
-        self._set_options(self.status_select, statuses)
-        self._set_options(self.action_select, actions)
-        self._set_options(self.label_select, labels)
+        if not self.pool_select.expanded:
+            self._set_options(self.pool_select, pools)
+        if not self.status_select.expanded:
+            self._set_options(self.status_select, statuses)
+        if not self.action_select.expanded:
+            self._set_options(self.action_select, actions)
+        if not self.label_select.expanded:
+            self._set_options(self.label_select, labels)
 
     def clear(self) -> None:
         for select_widget in (


### PR DESCRIPTION
## Summary
- avoid updating Select options while dropdown is open
- prevent jitter when scrolling the `Status` filter

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format .`
- `uv run --directory pkgs/standards --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards --package peagen pytest` *(fails: 57 errors)*
- `uv run --directory pkgs/standards --package peagen peagen local process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: ValueError)*
- `uv run --directory pkgs/standards --package peagen peagen remote process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_b_685937928bd883318252c620b82c0f89