### PR TITLE
Improve Peagen TUI pagination

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/tui.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/tui.py
@@ -18,9 +18,10 @@ def run_dashboard(
         "--gateway-url",
         help="Base URL of the Peagen gateway",
     ),
+    limit: int = typer.Option(50, "--limit", help="Tasks per page"),
 ) -> None:
     """Start the dashboard pointed at ``gateway_url``."""
     try:
-        QueueDashboardApp(gateway_url=gateway_url).run()
+        QueueDashboardApp(gateway_url=gateway_url, limit=limit).run()
     except (asyncio.CancelledError, KeyboardInterrupt):
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -740,6 +740,13 @@ async def pool_list(poolName: str, limit: int | None = None, offset: int = 0):
     return tasks
 
 
+@rpc.method("Pool.taskCount")
+async def pool_task_count(poolName: str) -> int:
+    """Return the number of queued tasks for *poolName*."""
+
+    return await queue.llen(f"{READY_QUEUE}:{poolName}")
+
+
 # ─────────────────────────── Worker RPCs ────────────────────────
 @rpc.method("Worker.register")
 async def worker_register(

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 from urllib.parse import urlparse
 
+import math
 import httpx
 from textual import events
 from textual.app import App, ComposeResult
@@ -32,6 +33,7 @@ from peagen.tui.components import (
     FileTree,
     FilterBar,
     ReconnectScreen,
+    NumberInputScreen,
     TaskDetailScreen,
     TaskTable,
     TemplatesView,
@@ -135,11 +137,14 @@ class RemoteBackend:
         self.tasks: List[dict] = []
         self.workers: Dict[str, dict] = {}
         self.last_error: str | None = None
+        self.total_tasks: int = 0
 
     async def refresh(self, limit: int | None = None, offset: int = 0) -> bool:
         try:
             await asyncio.gather(
-                self.fetch_tasks(limit=limit, offset=offset), self.fetch_workers()
+                self.fetch_tasks(limit=limit, offset=offset),
+                self.fetch_workers(),
+                self.fetch_task_count(),
             )
         except Exception as exc:
             self.last_error = str(exc)
@@ -192,6 +197,17 @@ class RemoteBackend:
             workers[info["id"]] = info
         self.workers = workers
 
+    async def fetch_task_count(self) -> None:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "3",
+            "method": "Pool.taskCount",
+            "params": {"poolName": "default"},
+        }
+        resp = await self.http.post(self.rpc_url, json=payload)
+        resp.raise_for_status()
+        self.total_tasks = int(resp.json().get("result", 0))
+
 
 class QueueDashboardApp(App):
     CSS = """
@@ -234,6 +250,8 @@ class QueueDashboardApp(App):
         ("escape", "clear_filters", "Clear Filters"),
         ("n", "next_page", "Next Page"),
         ("p", "prev_page", "Prev Page"),
+        ("j", "jump_page", "Jump Page"),
+        ("l", "change_limit", "Set Limit"),
         ("q", "quit", "Quit"),
     ]
 
@@ -267,7 +285,9 @@ class QueueDashboardApp(App):
     fail_len = reactive(0)
     worker_len = reactive(0)
 
-    def __init__(self, gateway_url: str = "http://localhost:8000") -> None:
+    def __init__(
+        self, gateway_url: str = "http://localhost:8000", limit: int = 50
+    ) -> None:
         super().__init__()
         ws_url = gateway_url.replace("http", "ws").rstrip("/") + "/ws/tasks"
         self.client = TaskStreamClient(ws_url)
@@ -286,7 +306,7 @@ class QueueDashboardApp(App):
         self._current_file: str | None = None
         self._remote_info: tuple | None = None
         self.ws_connected = False  # Track WebSocket connection status
-        self.limit = 50
+        self.limit = limit
         self.offset = 0
 
     async def on_mount(self):
@@ -691,6 +711,8 @@ class QueueDashboardApp(App):
             self.err_table.scroll_x = min(err_scroll_x, self.err_table.max_scroll_x)
             self.err_table.scroll_y = min(err_scroll_y, self.err_table.max_scroll_y)
 
+        self.update_page_info()
+
     async def on_open_url(self, event: events.OpenURL) -> None:
         if event.url.startswith("file://"):
             event.prevent_default()
@@ -712,6 +734,17 @@ class QueueDashboardApp(App):
             self.notify(message, severity=style, timeout=duration)
         else:
             self.log(f"[{style.upper()}] {message}")
+
+    def update_page_info(self) -> None:
+        """Update the footer with current page details."""
+
+        if hasattr(self, "footer"):
+            if self.limit:
+                total_pages = math.ceil(self.backend.total_tasks / self.limit)
+            else:
+                total_pages = 1
+            current_page = self.offset // self.limit + 1 if self.limit else 1
+            self.footer.page_info = f"Page {current_page}/{max(total_pages, 1)}"
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -969,6 +1002,7 @@ class QueueDashboardApp(App):
             group="data_refresh_worker",
         )
         self.trigger_data_processing(debounce=False)
+        self.update_page_info()
 
     def action_prev_page(self) -> None:
         if self.offset >= self.limit:
@@ -979,6 +1013,41 @@ class QueueDashboardApp(App):
                 group="data_refresh_worker",
             )
             self.trigger_data_processing(debounce=False)
+
+    def set_page(self, page: int) -> None:
+        if page < 1:
+            return
+        self.offset = (page - 1) * self.limit
+        self.run_worker(
+            self.backend.refresh(limit=self.limit, offset=self.offset),
+            exclusive=True,
+            group="data_refresh_worker",
+        )
+        self.trigger_data_processing(debounce=False)
+        self.update_page_info()
+
+    async def action_jump_page(self) -> None:
+        page = await self.push_screen(NumberInputScreen("Go to page"))
+        if page:
+            self.set_page(int(page))
+
+    def set_limit(self, new_limit: int) -> None:
+        if new_limit <= 0:
+            return
+        self.limit = new_limit
+        self.offset = 0
+        self.run_worker(
+            self.backend.refresh(limit=self.limit, offset=self.offset),
+            exclusive=True,
+            group="data_refresh_worker",
+        )
+        self.trigger_data_processing(debounce=False)
+        self.update_page_info()
+
+    async def action_change_limit(self) -> None:
+        new_limit = await self.push_screen(NumberInputScreen("Page size"))
+        if new_limit:
+            self.set_limit(int(new_limit))
 
     async def on_data_table_cell_selected(self, event: DataTable.CellSelected) -> None:
         if isinstance(event.value, str) and event.value.startswith("[link="):

--- a/pkgs/standards/peagen/peagen/tui/components/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/components/__init__.py
@@ -10,6 +10,7 @@ from .reconnect_screen import ReconnectScreen
 from .task_detail_screen import TaskDetailScreen
 from .task_table import TaskTable
 from .filter_bar import FilterBar
+from .number_input_screen import NumberInputScreen
 
 __all__ = [
     "DashboardFooter",
@@ -22,4 +23,5 @@ __all__ = [
     "TaskDetailScreen",
     "TaskTable",
     "FilterBar",
+    "NumberInputScreen",
 ]

--- a/pkgs/standards/peagen/peagen/tui/components/footer.py
+++ b/pkgs/standards/peagen/peagen/tui/components/footer.py
@@ -11,7 +11,8 @@ from textual.widgets import Footer
 class DashboardFooter(Footer):
     clock: reactive[str] = reactive("")
     metrics: reactive[str] = reactive("")
-    hint: str = "Tab: switch | S: sort | C: collapse | Esc: clear | N/P: page"
+    page_info: reactive[str] = reactive("")
+    hint: str = "Tab: switch | S: sort | C: collapse | Esc: clear | N/P: page | J: jump | L: limit"
 
     def on_mount(self) -> None:
         self.set_interval(1.0, self.update_metrics)
@@ -24,4 +25,8 @@ class DashboardFooter(Footer):
             self.metrics = "CPU: n/a | MEM: n/a"
 
     def render(self) -> str:
-        return f"{self.clock} | {self.metrics} | {self.hint}"
+        parts = [self.clock, self.metrics]
+        if self.page_info:
+            parts.append(self.page_info)
+        parts.append(self.hint)
+        return " | ".join(parts)

--- a/pkgs/standards/peagen/peagen/tui/components/number_input_screen.py
+++ b/pkgs/standards/peagen/peagen/tui/components/number_input_screen.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Center, Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label
+
+
+class NumberInputScreen(ModalScreen[int | None]):
+    """Prompt the user for a numeric input."""
+
+    def __init__(self, prompt: str) -> None:
+        super().__init__()
+        self.prompt = prompt
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - UI code
+        yield Center(
+            Vertical(
+                Label(self.prompt, id="prompt-label"),
+                Input(id="number-input"),
+                Horizontal(Button("OK", id="ok"), Button("Cancel", id="cancel")),
+            )
+        )
+
+    async def on_button_pressed(
+        self, event: Button.Pressed
+    ) -> None:  # pragma: no cover - UI code
+        if event.button.id == "ok":
+            value = self.query_one("#number-input", Input).value
+            self.dismiss(int(value)) if value.isdigit() else self.dismiss(None)
+        else:
+            self.dismiss(None)

--- a/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
@@ -1,11 +1,13 @@
 import pytest
 
 from peagen.tui.app import QueueDashboardApp
+from peagen.tui.components import DashboardFooter
 
 
 @pytest.mark.unit
-def test_pagination_actions():
+def test_pagination_actions(monkeypatch):
     app = QueueDashboardApp()
+    monkeypatch.setattr(app, "run_worker", lambda *a, **k: None)
     app.limit = 10
     app.offset = 0
     app.action_next_page()
@@ -14,3 +16,25 @@ def test_pagination_actions():
     assert app.offset == 0
     app.action_prev_page()
     assert app.offset == 0
+
+
+@pytest.mark.unit
+def test_set_page_and_limit_updates_offset(monkeypatch):
+    app = QueueDashboardApp(limit=10)
+    monkeypatch.setattr(app, "run_worker", lambda *a, **k: None)
+    app.set_page(3)
+    assert app.offset == 20
+    app.set_limit(5)
+    assert app.limit == 5
+    assert app.offset == 0
+
+
+@pytest.mark.unit
+def test_update_page_info(monkeypatch):
+    app = QueueDashboardApp(limit=10)
+    monkeypatch.setattr(app, "run_worker", lambda *a, **k: None)
+    app.footer = DashboardFooter()
+    app.backend.total_tasks = 95
+    app.offset = 20
+    app.update_page_info()
+    assert app.footer.page_info == "Page 3/10"


### PR DESCRIPTION
## Summary
- expose new `Pool.taskCount` RPC in gateway
- display page and limit controls in dashboard footer
- allow limit configuration via CLI and interactive change
- enable jumping to an arbitrary page in the TUI
- add `NumberInputScreen` for numeric prompts
- extend pagination unit tests

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format .`
- `ruff check pkgs/standards/peagen --fix`
- `uv run --directory pkgs/standards --package peagen pytest peagen/tests/unit/test_tui_pagination.py`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: Connection refused)*
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: TypeCheckError)*

------
https://chatgpt.com/codex/tasks/task_b_685a593704708331bb329d9d7e106a8e