### PR TITLE
Improve Peagen TUI pagination

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/components/footer.py
+++ b/pkgs/standards/peagen/peagen/tui/components/footer.py
@@ -11,10 +11,18 @@ from textual.widgets import Footer
 class DashboardFooter(Footer):
     clock: reactive[str] = reactive("")
     metrics: reactive[str] = reactive("")
-    hint: str = "Tab: switch | S: sort | C: collapse | Esc: clear | N/P: page"
+    page: reactive[str] = reactive("")
+    hint: str = (
+        "Tab: switch | S: sort | C: collapse | Esc: clear | "
+        "N/P: page | J: jump | L: limit"
+    )
 
     def on_mount(self) -> None:
         self.set_interval(1.0, self.update_metrics)
+
+    def set_page_info(self, current: int, total: int) -> None:
+        """Update the current pagination display."""
+        self.page = f"{current}/{total}" if total else f"{current}/?"
 
     def update_metrics(self) -> None:
         self.clock = datetime.now().strftime("%H:%M:%S")
@@ -24,4 +32,5 @@ class DashboardFooter(Footer):
             self.metrics = "CPU: n/a | MEM: n/a"
 
     def render(self) -> str:
-        return f"{self.clock} | {self.metrics} | {self.hint}"
+        page_part = f"Page {self.page} | " if self.page else ""
+        return f"{self.clock} | {self.metrics} | {page_part}{self.hint}"

--- a/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
@@ -15,3 +15,13 @@ def test_pagination_actions(monkeypatch):
     assert app.offset == 0
     app.action_prev_page()
     assert app.offset == 0
+    # cycle limit
+    app.action_cycle_limit()
+    assert app.limit != 10
+    # jump to page respecting bounds
+    app.queue_len = 30
+    app.limit = 10
+    app.action_jump_page(3)
+    assert app.offset == 20
+    app.action_jump_page(99)
+    assert app.offset == 20


### PR DESCRIPTION
## Summary
- add page indicator in dashboard footer
- allow cycling page size and jumping to a page
- show pagination info in footer
- cover new actions in pagination tests

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -q`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: File not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: No such option)*

------
https://chatgpt.com/codex/tasks/task_b_685a82903fa483319ad2aab86defe060