### PR TITLE
Improve Peagen TUI pagination

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -7,6 +7,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
+import math
 from urllib.parse import urlparse
 
 import httpx
@@ -33,6 +34,7 @@ from peagen.tui.components import (
     FilterBar,
     ReconnectScreen,
     TaskDetailScreen,
+    NumberInputScreen,
     TaskTable,
     TemplatesView,
     WorkersView,
@@ -234,6 +236,8 @@ class QueueDashboardApp(App):
         ("escape", "clear_filters", "Clear Filters"),
         ("n", "next_page", "Next Page"),
         ("p", "prev_page", "Prev Page"),
+        ("l", "set_limit", "Limit"),
+        ("j", "jump_page", "Jump Page"),
         ("q", "quit", "Quit"),
     ]
 
@@ -249,6 +253,8 @@ class QueueDashboardApp(App):
         "finished_at",
         "error",
     ]
+
+    LIMIT_OPTIONS = [10, 20, 50, 100]
 
     COLUMN_LABEL_TO_SORT_KEY = {
         "ID": "id",
@@ -447,11 +453,21 @@ class QueueDashboardApp(App):
             "collapsed": self.collapsed.copy(),
         }
         processed_data = self._perform_filtering_and_sorting(
-            all_tasks, current_filter_criteria
+            all_tasks,
+            current_filter_criteria,
+            limit=self.limit,
+            offset=self.offset,
         )
         self.call_later(self._update_ui_with_processed_data, processed_data, all_tasks)
 
-    def _perform_filtering_and_sorting(self, tasks_input: list, criteria: dict) -> dict:
+    def _perform_filtering_and_sorting(
+        self,
+        tasks_input: list,
+        criteria: dict,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> dict:
         tasks = list(tasks_input)
 
         if criteria.get("id"):
@@ -546,8 +562,14 @@ class QueueDashboardApp(App):
         )
         calculated_metrics["worker_len"] = len(current_workers)
 
+        page_tasks = tasks
+        if limit is not None:
+            start = max(0, offset)
+            end = start + limit
+            page_tasks = tasks[start:end]
+
         return {
-            "tasks_to_display": tasks,
+            "tasks_to_display": page_tasks,
             "workers_data": current_workers,
             "metrics_data": calculated_metrics,
             "collapsed_state": criteria["collapsed"],
@@ -689,6 +711,12 @@ class QueueDashboardApp(App):
 
             self.err_table.scroll_x = min(err_scroll_x, self.err_table.max_scroll_x)
             self.err_table.scroll_y = min(err_scroll_y, self.err_table.max_scroll_y)
+
+        if hasattr(self, "footer"):
+            current_page = self.offset // self.limit + 1
+            total_pages = max(1, math.ceil(self.queue_len / self.limit))
+            self.footer.set_page_info(current_page, total_pages)
+            self.sub_title = f"Page {current_page} of {total_pages}"
 
     async def on_open_url(self, event: events.OpenURL) -> None:
         if event.url.startswith("file://"):
@@ -982,6 +1010,73 @@ class QueueDashboardApp(App):
             else:
                 self.run_worker(coro, exclusive=True, group="data_refresh_worker")
             self.trigger_data_processing(debounce=False)
+
+    def action_set_limit(self, limit: int | None = None) -> None:
+        """Set the number of tasks shown per page."""
+
+        if limit is None:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(self._prompt_and_set_limit())
+            else:
+                self.run_worker(self._prompt_and_set_limit(), exclusive=True)
+            return
+
+        if limit <= 0:
+            limit = 1
+        self.limit = limit
+        self.offset = 0
+        coro = self.backend.refresh(limit=self.limit, offset=self.offset)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(coro)
+        else:
+            self.run_worker(coro, exclusive=True, group="data_refresh_worker")
+        self.trigger_data_processing(debounce=False)
+
+    def action_jump_page(self, page: int | None = None) -> None:
+        """Jump directly to *page* if provided or prompt the user."""
+        if page is None:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(self._prompt_and_jump())
+            else:
+                self.run_worker(self._prompt_and_jump(), exclusive=True)
+            return
+        self._apply_jump_page(page)
+
+    def _apply_jump_page(self, page: int) -> None:
+        if page <= 0:
+            page = 1
+        max_page = max(1, math.ceil(self.queue_len / self.limit))
+        if page > max_page:
+            page = max_page
+        self.offset = (page - 1) * self.limit
+        coro = self.backend.refresh(limit=self.limit, offset=self.offset)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(coro)
+        else:
+            self.run_worker(coro, exclusive=True, group="data_refresh_worker")
+        self.trigger_data_processing(debounce=False)
+
+    async def _prompt_and_jump(self) -> None:
+        current_page = self.offset // self.limit + 1
+        total_pages = max(1, math.ceil(self.queue_len / self.limit))
+        prompt = f"Jump to page (1-{total_pages})"
+        page = await self.push_screen_wait(NumberInputScreen(prompt, current_page))
+        if page is not None:
+            self._apply_jump_page(page)
+
+    async def _prompt_and_set_limit(self) -> None:
+        prompt = "Items per page"
+        limit = await self.push_screen_wait(NumberInputScreen(prompt, self.limit))
+        if limit is not None:
+            self.action_set_limit(limit)
 
     async def on_data_table_cell_selected(self, event: DataTable.CellSelected) -> None:
         if isinstance(event.value, str) and event.value.startswith("[link="):

--- a/pkgs/standards/peagen/peagen/tui/components/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/components/__init__.py
@@ -8,6 +8,7 @@ from .workers_view import WorkersView
 from .templates_view import TemplatesView
 from .reconnect_screen import ReconnectScreen
 from .task_detail_screen import TaskDetailScreen
+from .number_input_screen import NumberInputScreen
 from .task_table import TaskTable
 from .filter_bar import FilterBar
 
@@ -20,6 +21,7 @@ __all__ = [
     "TemplatesView",
     "ReconnectScreen",
     "TaskDetailScreen",
+    "NumberInputScreen",
     "TaskTable",
     "FilterBar",
 ]

--- a/pkgs/standards/peagen/peagen/tui/components/footer.py
+++ b/pkgs/standards/peagen/peagen/tui/components/footer.py
@@ -11,10 +11,18 @@ from textual.widgets import Footer
 class DashboardFooter(Footer):
     clock: reactive[str] = reactive("")
     metrics: reactive[str] = reactive("")
-    hint: str = "Tab: switch | S: sort | C: collapse | Esc: clear | N/P: page"
+    page: reactive[str] = reactive("")
+    hint: str = (
+        "Tab: switch | S: sort | C: collapse | Esc: clear | "
+        "N/P: page | J: jump | L: limit"
+    )
 
     def on_mount(self) -> None:
         self.set_interval(1.0, self.update_metrics)
+
+    def set_page_info(self, current: int, total: int) -> None:
+        """Update the current pagination display."""
+        self.page = f"{current}/{total}" if total else f"{current}/?"
 
     def update_metrics(self) -> None:
         self.clock = datetime.now().strftime("%H:%M:%S")
@@ -24,4 +32,5 @@ class DashboardFooter(Footer):
             self.metrics = "CPU: n/a | MEM: n/a"
 
     def render(self) -> str:
-        return f"{self.clock} | {self.metrics} | {self.hint}"
+        page_part = f"Page {self.page} | " if self.page else ""
+        return f"{self.clock} | {self.metrics} | {page_part}{self.hint}"

--- a/pkgs/standards/peagen/peagen/tui/components/number_input_screen.py
+++ b/pkgs/standards/peagen/peagen/tui/components/number_input_screen.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label
+
+
+class NumberInputScreen(ModalScreen[int | None]):
+    """Prompt the user for a numeric value."""
+
+    def __init__(self, prompt: str, initial: int) -> None:
+        super().__init__()
+        self.prompt = prompt
+        self.initial = initial
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - UI code
+        with Vertical(id="number_input_box"):
+            yield Label(self.prompt)
+            yield Input(
+                value=str(self.initial),
+                id="number_input",
+                placeholder="value",
+            )
+            with Horizontal():
+                yield Button("OK", id="submit", variant="primary")
+                yield Button("Cancel", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "submit":
+            value = self.query_one("#number_input", Input).value
+            try:
+                num = int(value)
+            except Exception:
+                num = None
+            self.dismiss(num)
+        elif event.button.id == "cancel":
+            self.dismiss(None)

--- a/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
@@ -15,3 +15,56 @@ def test_pagination_actions(monkeypatch):
     assert app.offset == 0
     app.action_prev_page()
     assert app.offset == 0
+    # set limit directly
+    app.action_set_limit(20)
+    assert app.limit == 20
+    # jump to page respecting bounds
+    app.queue_len = 30
+    app.limit = 10
+    app.action_jump_page(3)
+    assert app.offset == 20
+    app.action_jump_page(99)
+    assert app.offset == 20
+
+
+@pytest.mark.unit
+def test_perform_filtering_limit_offset():
+    app = QueueDashboardApp()
+    tasks = [
+        {
+            "id": i,
+            "pool": "default",
+            "status": "running",
+            "payload": {"action": "a"},
+            "labels": [],
+        }
+        for i in range(30)
+    ]
+    result = app._perform_filtering_and_sorting(
+        tasks,
+        {"collapsed": set()},
+        limit=10,
+        offset=20,
+    )
+    ids = [t["id"] for t in result["tasks_to_display"]]
+    assert ids == list(range(20, 30))
+
+
+@pytest.mark.unit
+def test_header_page_info():
+    app = QueueDashboardApp()
+    data = {
+        "tasks_to_display": [],
+        "workers_data": [],
+        "metrics_data": {
+            "queue_len": 50,
+            "done_len": 0,
+            "fail_len": 0,
+            "worker_len": 0,
+        },
+        "collapsed_state": set(),
+    }
+    app.limit = 10
+    app.offset = 20
+    app._update_ui_with_processed_data(data, [])
+    assert app.sub_title == "Page 3 of 5"


### PR DESCRIPTION
## Summary
- add NumberInputScreen for numeric prompts
- use modal for page jumps and setting limit
- update pagination unit test for new set-limit action
- slice data in `_perform_filtering_and_sorting` using limit/offset
- show current and total pages in the footer
- display page information in the header

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -q`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: File not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: No such option)*

------
https://chatgpt.com/codex/tasks/task_b_685a82903fa483319ad2aab86defe060