### PR TITLE
Fix copy across TUI screens

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -26,6 +26,7 @@ from textual.widgets import (
     TabbedContent,
     TabPane,
     TextArea,
+    Tree,
 )
 
 from peagen.tui.components import (
@@ -230,7 +231,7 @@ class QueueDashboardApp(App):
         ("ctrl+s", "save_file", "Save"),
         ("c", "toggle_children", "Collapse"),
         ("space", "toggle_children", "Collapse"),
-        ("ctrl+c", "copy_id", "Copy"),
+        ("ctrl+c", "copy_selection", "Copy"),
         ("ctrl+p", "paste_clipboard", "Paste"),
         ("s", "cycle_sort", "Sort"),
         ("escape", "clear_filters", "Clear Filters"),
@@ -712,12 +713,11 @@ class QueueDashboardApp(App):
             self.err_table.scroll_x = min(err_scroll_x, self.err_table.max_scroll_x)
             self.err_table.scroll_y = min(err_scroll_y, self.err_table.max_scroll_y)
 
+        current_page = self.offset // self.limit + 1
+        total_pages = max(1, math.ceil(self.queue_len / self.limit))
         if hasattr(self, "footer"):
-            current_page = self.offset // self.limit + 1
-            total_pages = max(1, math.ceil(self.queue_len / self.limit))
             self.footer.set_page_info(current_page, total_pages)
-            self.sub_title = f"Page {current_page} of {total_pages}"
-
+        self.sub_title = f"Page {current_page} of {total_pages}"
 
     async def on_open_url(self, event: events.OpenURL) -> None:
         if event.url.startswith("file://"):
@@ -944,7 +944,9 @@ class QueueDashboardApp(App):
             self.filter_bar.clear()
         self.trigger_data_processing()
 
-    def action_copy_id(self) -> None:
+    def action_copy_selection(self) -> None:
+        """Copy highlighted or focused text to the clipboard."""
+
         widget = self.focused
         text = ""
         if isinstance(widget, DataTable):
@@ -974,8 +976,16 @@ class QueueDashboardApp(App):
                     text = str(value)
         elif isinstance(widget, TextArea):
             text = widget.selected_text or widget.text
+        elif isinstance(widget, Tree):
+            node = getattr(widget, "cursor_node", None)
+            if node is not None:
+                text = str(getattr(node, "label", ""))
         elif hasattr(widget, "selected_text"):
             text = widget.selected_text
+        elif hasattr(widget, "text"):
+            text = widget.text
+        elif hasattr(widget, "value"):
+            text = str(widget.value)
         if text:
             clipboard_copy(text)
 

--- a/pkgs/standards/peagen/tests/unit/test_tui_clipboard.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_clipboard.py
@@ -25,7 +25,7 @@ def make_property(value):
 
 
 @pytest.mark.unit
-def test_action_copy_id_datatable(monkeypatch):
+def test_action_copy_selection_datatable(monkeypatch):
     captured = {}
 
     def fake_copy(text):
@@ -36,13 +36,13 @@ def test_action_copy_id_datatable(monkeypatch):
     monkeypatch.setattr(QueueDashboardApp, "focused", make_property(table))
 
     app = QueueDashboardApp()
-    app.action_copy_id()
+    app.action_copy_selection()
 
     assert captured["text"] == "cell"
 
 
 @pytest.mark.unit
-def test_action_copy_id_input(monkeypatch):
+def test_action_copy_selection_input(monkeypatch):
     captured = {}
 
     def fake_copy(text):
@@ -58,7 +58,7 @@ def test_action_copy_id_input(monkeypatch):
     monkeypatch.setattr(QueueDashboardApp, "focused", make_property(dummy))
 
     app = QueueDashboardApp()
-    app.action_copy_id()
+    app.action_copy_selection()
 
     assert captured["text"] == "sel"
 


### PR DESCRIPTION
## Summary
- rename `action_copy_id` to `action_copy_selection`
- allow copying selected text from DataTables, TextAreas, Trees and other widgets
- update keybinding and tests
- always update `sub_title` in pagination helper

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -q` *(fails: command succeeded)*
- `uv run --directory pkgs/standards/peagen --package peagen pytest tests/unit/test_tui_pagination.py::test_header_page_info -q` *(fails: command succeeded)*
- `uv run --directory pkgs/standards/peagen --package peagen peagen local -q process tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: No such option)*
- `uv run --directory pkgs/standards/peagen --package peagen peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec_local.yaml` *(fails: ConnectError)*

------
https://chatgpt.com/codex/tasks/task_b_685aa78e84e88331bcbc8e7cf5b079ef