### PR TITLE
Add autoapi v2 integration tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -1,0 +1,57 @@
+from typing import Iterator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import Column, ForeignKey, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Session
+
+from autoapi.v2 import AutoAPI, Base
+from autoapi.v2.engines import blocking_postgres_engine, blocking_sqlite_engine
+from autoapi.v2.mixins import BulkCapable, GUIDPk
+
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def session_factory(request):
+    if request.param == "postgres":
+        try:
+            engine, SessionLocal = blocking_postgres_engine()
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+        except Exception:
+            pytest.skip("PostgreSQL not available")
+    else:
+        engine, SessionLocal = blocking_sqlite_engine()
+    Base.metadata.clear()
+    request.addfinalizer(engine.dispose)
+    return SessionLocal
+
+
+@pytest_asyncio.fixture()
+async def api_client(session_factory):
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk, BulkCapable):
+        __tablename__ = "items"
+        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        name = Column(String, nullable=False)
+        _nested_path = "/tenants/{tenant_id}"
+
+    def get_db() -> Iterator[Session]:
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db)
+    api.initialize_sync()
+    app = FastAPI()
+    app.include_router(api.router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, api, Item

--- a/pkgs/standards/autoapi/tests/i9n/test_basic_http.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_basic_http.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_basic_endpoints(api_client):
+    client, _, _ = api_client
+
+    resp = await client.get("/openapi.json")
+    assert resp.status_code == 200
+
+    health = await client.get("/healthz")
+    assert health.status_code == 200
+    assert health.json().get("ok") is True
+
+    methodz = await client.get("/methodz")
+    assert methodz.status_code == 200
+    assert methodz.json()
+
+    rpc_resp = await client.post("/rpc", json={"method": "noop", "params": {}, "id": 1})
+    assert rpc_resp.status_code == 200

--- a/pkgs/standards/autoapi/tests/i9n/test_hooks.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hooks.py
@@ -1,0 +1,26 @@
+import pytest
+from autoapi.v2 import Phase
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_hooks_modify_request_and_response(api_client):
+    client, api, _ = api_client
+
+    @api.hook(Phase.PRE_TX_BEGIN, method="Items.create")
+    async def upcase(ctx):
+        ctx["env"].params["name"] = ctx["env"].params["name"].upper()
+
+    @api.hook(Phase.POST_RESPONSE, method="Items.create")
+    async def enrich(ctx):
+        ctx["response"].result["hooked"] = True
+
+    t = await client.post("/tenants", json={"name": "tenant"})
+    tid = t.json()["id"]
+    res = await client.post(
+        "/rpc",
+        json={"method": "Items.create", "params": {"tenant_id": tid, "name": "foo"}},
+    )
+    data = res.json()["result"]
+    assert data["name"] == "FOO"
+    assert data["hooked"] is True

--- a/pkgs/standards/autoapi/tests/i9n/test_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_parity.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_rest_rpc_parity(api_client):
+    client, _, Item = api_client
+    t = await client.post("/tenants", json={"name": "acme"})
+    tenant_id = t.json()["id"]
+
+    rest = await client.post("/items", json={"tenant_id": tenant_id, "name": "foo"})
+    item = rest.json()
+
+    rpc = await client.post(
+        "/rpc",
+        json={
+            "method": "Items.create",
+            "params": {"tenant_id": tenant_id, "name": "foo"},
+        },
+    )
+    rpc_item = rpc.json()["result"]
+    assert item["name"] == rpc_item["name"]
+    assert item["tenant_id"] == rpc_item["tenant_id"]
+
+    rid = item["id"]
+    rest_read = await client.get(f"/items/{rid}")
+    rpc_read = await client.post(
+        "/rpc", json={"method": "Items.read", "params": {"id": rid}}
+    )
+    assert rest_read.json() == rpc_read.json()["result"]
+
+    rest_list = await client.get("/items")
+    rpc_list = await client.post("/rpc", json={"method": "Items.list"})
+    assert len(rest_list.json()) == len(rpc_list.json()["result"])

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -1,0 +1,34 @@
+import pytest
+from autoapi.v2 import AutoAPI
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_generation(api_client):
+    client, api, Item = api_client
+
+    create_model = AutoAPI.get_schema(Item, "create")
+    read_model = AutoAPI.get_schema(Item, "read")
+    update_model = AutoAPI.get_schema(Item, "update")
+    delete_model = AutoAPI.get_schema(Item, "delete")
+    list_model = AutoAPI.get_schema(Item, "list")
+
+    assert create_model.__name__ == "ItemCreate"
+    assert read_model.__name__ == "ItemRead"
+    assert update_model.__name__ == "ItemUpdate"
+    assert delete_model.__name__ == "ItemDelete"
+    assert list_model.__name__ == "ItemListParams"
+
+    spec = (await client.get("/openapi.json")).json()
+    schemas = spec["components"]["schemas"]
+    assert create_model.__name__ in schemas
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_bulk_operation_schema(api_client):
+    client, _, _ = api_client
+    spec = (await client.get("/openapi.json")).json()
+    assert "/items/bulk" in spec["paths"]
+    ops = spec["paths"]["/items/bulk"]
+    assert "post" in ops and "delete" in ops

--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -1,0 +1,34 @@
+import pytest
+
+CRUD_MAP = {
+    "create": ("post", "/items"),
+    "list": ("get", "/items"),
+    "clear": ("delete", "/items"),
+    "read": ("get", "/items/{item_id}"),
+    "update": ("patch", "/items/{item_id}"),
+    "delete": ("delete", "/items/{item_id}"),
+}
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_route_and_method_symmetry(api_client):
+    client, _, _ = api_client
+    spec = (await client.get("/openapi.json")).json()
+    paths = spec["paths"]
+    methods = await client.get("/methodz")
+    method_list = methods.json()
+
+    for verb, (http_verb, path) in CRUD_MAP.items():
+        assert path in paths
+        assert http_verb in paths[path]
+        assert f"Items.{verb}" in method_list
+
+    nested_base = "/tenants/{tenant_id}"
+    assert nested_base in paths
+    for verb in ("create", "list", "clear"):
+        assert CRUD_MAP[verb][0] in paths[nested_base]
+    nested_item = "/tenants/{tenant_id}/{item_id}"
+    assert nested_item in paths
+    for verb in ("read", "update", "delete"):
+        assert CRUD_MAP[verb][0] in paths[nested_item]

--- a/pkgs/standards/autoapi/tests/i9n/test_transactional.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_transactional.py
@@ -1,0 +1,45 @@
+import pytest
+import uuid
+from autoapi.v2.transactional import transactional
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_transaction_decorator(api_client):
+    client, api, Item = api_client
+
+    def fail(params, db):
+        obj = Item(tenant_id=uuid.UUID(params["tenant_id"]), name=params["name"])
+        db.add(obj)
+        db.flush()
+        if params.get("fail"):
+            raise ValueError("boom")
+        return {"id": obj.id}
+
+    fail = transactional(api, fail)
+
+    api.rpc["Items.fail"] = fail
+    api._method_ids["Items.fail"] = None
+
+    t = await client.post("/tenants", json={"name": "tx"})
+    tid = t.json()["id"]
+
+    bad = await client.post(
+        "/rpc",
+        json={
+            "method": "Items.fail",
+            "params": {"tenant_id": tid, "name": "a", "fail": True},
+        },
+    )
+    assert bad.json()["error"] is not None
+
+    lst = await client.get("/items")
+    assert lst.json() == []
+
+    ok = await client.post(
+        "/rpc",
+        json={"method": "Items.fail", "params": {"tenant_id": tid, "name": "b"}},
+    )
+    assert ok.json()["result"]["id"]
+    lst2 = await client.get("/items")
+    assert len(lst2.json()) == 1


### PR DESCRIPTION
## Summary
- implement integration tests for autoapi/v2
- cover basic endpoints, schema generation, parity and hooks
- add transactional and method symmetry tests

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e489c03a48331b85b2d62b591da68