### PR TITLE
Fix autoapi tests

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -107,7 +107,7 @@ class AutoAPI:
     async def initialize_async(self):
         """Initialize async database schema. Call this during app startup."""
         if not self._ddl_executed and self.get_async_db:
-            async with self.get_async_db() as adb:
+            async for adb in self.get_async_db():
                 # Get the engine from the session
                 engine = adb.get_bind()
                 await adb.run_sync(
@@ -117,6 +117,7 @@ class AutoAPI:
                         tables=self.tables,
                     )
                 )
+                break
             self._ddl_executed = True
 
     def initialize_sync(self):

--- a/pkgs/standards/autoapi/autoapi/v2/impl.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl.py
@@ -307,8 +307,9 @@ def _register_routes_and_rpcs(  # noqa: N802
                         return await _run(core, p, db)
 
             _impl.__name__ = f"{verb}_{tab}"
-            _impl.__signature__ = inspect.Signature(parameters=params)
-            return functools.wraps(_impl)(_impl)
+            wrapped = functools.wraps(_impl)(_impl)
+            wrapped.__signature__ = inspect.Signature(parameters=params)
+            return wrapped
 
         # mount on every relevant router
         for r in routers:

--- a/pkgs/standards/autoapi/pyproject.toml
+++ b/pkgs/standards/autoapi/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     "swarmauri_standard",
     "fastapi>=0.100.0",
     "pydantic>=2.0.0",
+    "sqlalchemy>=2.0",
+    "aiosqlite>=0.19.0",
+    "httpx>=0.27.0",
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/autoapi/tests/i9n/test_basic_http.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_basic_http.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_basic_endpoints(api_client):
-    client, _, _ = await api_client
+    client, _, _ = api_client
 
     resp = await client.get("/openapi.json")
     assert resp.status_code == 200

--- a/pkgs/standards/autoapi/tests/i9n/test_hooks.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hooks.py
@@ -5,7 +5,7 @@ from autoapi.v2 import Phase
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_hooks_modify_request_and_response(api_client):
-    client, api, _ = await api_client
+    client, api, _ = api_client
 
     @api.hook(Phase.PRE_TX_BEGIN, method="Items.create")
     async def upcase(ctx):

--- a/pkgs/standards/autoapi/tests/i9n/test_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_parity.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_rest_rpc_parity(api_client):
-    client, _, Item = await api_client
+    client, _, Item = api_client
     t = await client.post("/tenants", json={"name": "acme"})
     tenant_id = t.json()["id"]
 

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -5,7 +5,7 @@ from autoapi.v2 import AutoAPI
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_schema_generation(api_client):
-    client, api, Item = await api_client
+    client, api, Item = api_client
 
     create_model = AutoAPI.get_schema(Item, "create")
     read_model = AutoAPI.get_schema(Item, "read")
@@ -27,7 +27,7 @@ async def test_schema_generation(api_client):
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_bulk_operation_schema(api_client):
-    client, _, _ = await api_client
+    client, _, _ = api_client
     spec = (await client.get("/openapi.json")).json()
     assert "/items/bulk" in spec["paths"]
     ops = spec["paths"]["/items/bulk"]

--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -13,7 +13,7 @@ CRUD_MAP = {
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_route_and_method_symmetry(api_client):
-    client, _, _ = await api_client
+    client, _, _ = api_client
     spec = (await client.get("/openapi.json")).json()
     paths = spec["paths"]
     methods = await client.get("/methodz")

--- a/pkgs/standards/autoapi/tests/i9n/test_transactional.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_transactional.py
@@ -6,7 +6,7 @@ from autoapi.v2.transactional import transactional
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_transaction_decorator(api_client):
-    client, api, Item = await api_client
+    client, api, Item = api_client
 
     def fail(params, db):
         obj = Item(tenant_id=uuid.UUID(params["tenant_id"]), name=params["name"])


### PR DESCRIPTION
## Summary
- add missing deps to autoapi
- support async DB generator in autoapi init
- fix route signatures in autoapi impl
- make autoapi tests use an in-memory DB and synchronous sessions
- adjust tests not to await fixture

## Testing
- `uv run --package autoapi --directory pkgs/standards pytest autoapi/tests -q`

------
https://chatgpt.com/codex/tasks/task_b_686e66fec78c8331b0cfbd6119f1f09c