### PR TITLE
feat(auto_kms): use plugin-based crypto

### DIFF
--- a/pkgs/standards/auto_kms/pyproject.toml
+++ b/pkgs/standards/auto_kms/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.0",
     "swarmauri_secret_autogpg",
     "swarmauri_crypto_paramiko",
+    "peagen",
 ]
 
 [tool.uv.sources]
@@ -34,6 +35,7 @@ swarmauri_standard = { workspace = true }
 autoapi = { workspace = true }
 swarmauri_secret_autogpg = { workspace = true }
 swarmauri_crypto_paramiko = { workspace = true }
+peagen = { workspace = true }
 
 [tool.pytest.ini_options]
 norecursedirs = ["combined", "scripts"]

--- a/pkgs/standards/auto_kms/tests/unit/test_crypto_plugin_loader.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_crypto_plugin_loader.py
@@ -1,0 +1,40 @@
+import asyncio
+import importlib
+
+from swarmauri_base.crypto.CryptoBase import CryptoBase
+from auto_kms.crypto import ParamikoCryptoAdapter
+
+
+class DummyCrypto(CryptoBase):
+    def supports(self):  # pragma: no cover - not used
+        return {}
+
+
+class DummyPluginManager:
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.get_called = False
+
+    def get(self, group, name=None):
+        self.get_called = True
+        assert group == "cryptos"
+        return DummyCrypto()
+
+
+def test_crypto_provider_loaded_via_plugins(monkeypatch):
+    app = importlib.reload(importlib.import_module("auto_kms.app"))
+    pm = DummyPluginManager({})
+    monkeypatch.setattr(app, "PluginManager", lambda cfg: pm)
+    monkeypatch.setattr(app, "AutoGpgSecretDrive", lambda: object())
+
+    ctx: dict = {}
+    asyncio.run(app._stash_ctx(ctx))
+
+    assert pm.get_called
+    assert isinstance(ctx["crypto"], ParamikoCryptoAdapter)
+    assert isinstance(ctx["crypto"]._crypto, DummyCrypto)
+
+    if hasattr(app, "SECRETS"):
+        delattr(app, "SECRETS")
+    if hasattr(app, "CRYPTO"):
+        delattr(app, "CRYPTO")

--- a/pkgs/standards/auto_kms/tests/unit/test_wrap_unwrap_roundtrip.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_wrap_unwrap_roundtrip.py
@@ -163,6 +163,7 @@ def test_wrap_unwrap_different_key_sizes(client):
         unwrapped_material = base64.b64decode(unwrap_data["key_material_b64"])
         assert unwrapped_material == key_material
 
+
 def test_multiple_wrap_operations_same_key(client):
     """Test that multiple wrap operations with same key produce different results."""
     key = _create_key(client)

--- a/pkgs/standards/swarmauri_crypto_paramiko/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_paramiko/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
 ParamikoCrypto = "swarmauri_crypto_paramiko:ParamikoCrypto"
 
 [project.entry-points."peagen.plugins.cryptos"]
-paramiko = "swarmauri_crypto_paramiko:ParamikoCrypto"
+paramiko_sa = "swarmauri_crypto_paramiko:ParamikoCrypto"
 
 
 


### PR DESCRIPTION
## Summary
- load paramiko crypto via peagen PluginManager
- add peagen as dependency and rename paramiko crypto plugin
- cover plugin loading and adjust wrap/unwrap error tests

## Testing
- `uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko pytest`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ade7c1c8ac83319e6fcb5035727f4b