### PR TITLE
feat: integrate key provider plugin into peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/publickey.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/publickey.py
@@ -8,7 +8,7 @@ from typing import Optional
 import typer
 from httpx import HTTPError
 
-from peagen.plugins.cryptos import ParamikoCrypto
+from peagen.core import keys_core
 from peagen.core.publickey_core import login as core_login
 from peagen.defaults import DEFAULT_GATEWAY
 
@@ -40,7 +40,7 @@ def create(
 ) -> None:
     """Ensure a key-pair exists locally."""
     try:
-        ParamikoCrypto(key_dir=key_dir, passphrase=passphrase)
+        keys_core.create_keypair(key_dir, passphrase)
         typer.echo(f"✅  Created key-pair in {key_dir}")
     except Exception as exc:  # noqa: BLE001
         typer.echo(f"❌  {exc}", err=True)
@@ -74,8 +74,6 @@ def upload(
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
-
-    ParamikoCrypto(key_dir=key_dir, passphrase=passphrase)
 
     try:
         reply = core_login(

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from contextlib import contextmanager
 from pathlib import Path
 
+import os
+import anyio
 import httpx
 from autoapi_client import AutoAPIClient
 from autoapi.v2 import get_schema
@@ -25,28 +27,23 @@ from peagen.defaults import DEFAULT_GATEWAY
 from peagen.orm import DeployKey
 from peagen.plugins import PluginManager
 
-# ───────────────────────── cryptography layer ───────────────────────────
-from peagen.plugins.cryptos import ParamikoCrypto, CryptoBase
+from swarmauri_core.keys.types import KeyAlg, KeyClass, KeySpec, ExportPolicy
+from swarmauri_core.crypto.types import KeyUse
 
 
-# -----------------------------------------------------------------------#
-# Internal helpers
-# -----------------------------------------------------------------------#
-def _get_crypto(
-    key_dir: str | Path | None = None,
-    passphrase: str | None = None,
-) -> CryptoBase:
+def _get_key_provider():
+    """Return a key provider plugin instance.
+
+    Falls back to ``SshKeyProvider`` when no plugin is configured.
     """
-    Resolve a `CryptoBase` provider through the plugin manager.
-    Fallback ➜ `ParamikoCrypto` when no plugin is configured.
-    """
-    cfg = resolve_cfg()  # helper loads ~/.peagen.toml
+    cfg = resolve_cfg()
     pm = PluginManager(cfg)
     try:
-        crypto_cls = pm.get("cryptos")  # user-supplied plugin
+        return pm.get("key_providers")
     except KeyError:
-        crypto_cls = ParamikoCrypto  # built-in default
-    return crypto_cls(key_dir=key_dir, passphrase=passphrase)
+        from swarmauri_keyprovider_ssh import SshKeyProvider
+
+        return SshKeyProvider()
 
 
 @contextmanager
@@ -74,8 +71,36 @@ def create_keypair(
     -------
     dict  { "fingerprint": str, "public_key": str }
     """
-    drv = _get_crypto(key_dir, passphrase)
-    return {"fingerprint": drv.fingerprint(), "public_key": drv.public_key_str()}
+    key_dir = Path(key_dir or Path.home() / ".peagen" / "keys")
+    kp = _get_key_provider()
+
+    priv_path = key_dir / "ssh-private"
+    pub_path = key_dir / "ssh-public"
+    key_dir.mkdir(parents=True, exist_ok=True)
+
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        label="peagen",
+    )
+
+    if priv_path.exists() and pub_path.exists():
+        material = priv_path.read_bytes()
+        public = pub_path.read_bytes()
+        ref = anyio.run(kp.import_key, spec, material, public=public)
+    else:
+        ref = anyio.run(kp.create_key, spec)
+        if ref.material:
+            priv_path.write_bytes(ref.material)
+            os.chmod(priv_path, 0o600)
+        if ref.public:
+            pub_path.write_bytes(ref.public)
+
+    fingerprint = ref.tags.get("ssh_fingerprint", getattr(ref, "fingerprint", ""))
+    public_key = (ref.public or b"").decode().strip()
+    return {"fingerprint": fingerprint, "public_key": public_key}
 
 
 def upload_public_key(
@@ -83,14 +108,14 @@ def upload_public_key(
     passphrase: str | None = None,
     gateway_url: str = DEFAULT_GATEWAY,
 ) -> dict:
-    drv = _get_crypto(key_dir, passphrase)
+    info = create_keypair(key_dir, passphrase)
     SCreateIn = _schema("create")
     SRead = _schema("read")
 
     with _rpc(gateway_url) as rpc:
         res = rpc.call(
             "DeployKeys.create",
-            params=SCreateIn(key=drv.public_key_str()),
+            params=SCreateIn(key=info["public_key"]),
             out_schema=SRead,
         )
     return res.model_dump()

--- a/pkgs/standards/peagen/peagen/core/publickey_core.py
+++ b/pkgs/standards/peagen/peagen/core/publickey_core.py
@@ -20,7 +20,7 @@ from autoapi.v2 import get_schema  # ← schema helper
 from peagen.orm import PublicKey  # ORM resource
 
 from peagen.defaults import DEFAULT_GATEWAY, DEFAULT_SUPER_USER_ID
-from peagen.plugins.cryptos import ParamikoCrypto
+from peagen.core import keys_core
 
 __all__ = ["login"]
 
@@ -48,8 +48,8 @@ def login(
         JSON-RPC error returned by the gateway.
     """
     # 1 ─ ensure local SSH key-pair
-    drv = ParamikoCrypto(key_dir=key_dir, passphrase=passphrase)
-    public_key = drv.public_key_str()  # returns single-line OpenSSH key
+    kp = keys_core.create_keypair(key_dir, passphrase)
+    public_key = kp["public_key"]
 
     # 2 ─ build request/response schemas dynamically
     SCreate = _schema("create")

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -7,6 +7,7 @@ from types import ModuleType
 from typing import Any, Dict, Optional
 
 from peagen.errors import InvalidPluginSpecError
+from swarmauri_base.keys import KeyProviderBase
 
 # ---------------------------------------------------------------------------
 # Config – group key → (entry-point group string, expected base class)
@@ -30,6 +31,7 @@ GROUPS = {
     # keys and secrets
     "cryptos": ("peagen.plugins.cryptos", object),
     "secrets_drivers": ("peagen.plugins.secret_drivers", object),
+    "key_providers": ("swarmauri.key_providers", KeyProviderBase),
     # template sets remain in the top-level package
     "template_sets": ("peagen.template_sets", None),
 }
@@ -191,6 +193,11 @@ class PluginManager:
             "section": "cryptos",
             "items": "adapters",
             "default": "default_crypto",
+        },
+        "key_providers": {
+            "section": "key_providers",
+            "items": "providers",
+            "default": "default_provider",
         },
     }
 


### PR DESCRIPTION
## Summary
- add `key_providers` plugin group and configuration
- load key providers via PluginManager and default to `SshKeyProvider`
- update public key helper and CLI to use key provider plugin

## Testing
- `uv run --directory . --package peagen ruff check peagen/plugins/__init__.py peagen/core/keys_core.py peagen/core/publickey_core.py peagen/cli/commands/publickey.py --fix`
- `uv run --directory . --package peagen pytest` *(fails: MappedAnnotationError in auto_authn ORM)*

------
https://chatgpt.com/codex/tasks/task_b_68adf051ed0c8331859ad0954b915fa5