### PR TITLE
feat: integrate key provider plugin into peagen

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/backends.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/backends.py
@@ -22,14 +22,16 @@ is handled in `fastapi_deps.py` or route handlers.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Optional, Iterable
+from typing import Iterable, Optional, TYPE_CHECKING
 
 from sqlalchemy import Select, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .crypto import verify_pw
-from .orm.tables import ApiKey, Client, ServiceKey, User
 from .typing import Principal
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from .orm.tables import ApiKey, Client, ServiceKey, User
 
 
 class AuthError(Exception):
@@ -53,7 +55,9 @@ class PasswordBackend:
     >>> user = await backend.authenticate(db, "alice", "pa$$w0rd")
     """
 
-    async def _get_user_stmt(self, identifier: str) -> Select[tuple[User]]:
+    async def _get_user_stmt(self, identifier: str) -> Select[tuple["User"]]:
+        from .orm.tables import User
+
         return select(User).where(
             or_(User.username == identifier, User.email == identifier),
             User.is_active.is_(True),
@@ -62,7 +66,7 @@ class PasswordBackend:
     async def authenticate(
         self, db: AsyncSession, identifier: str, password: str
     ) -> User:
-        row: Optional[User] = await db.scalar(await self._get_user_stmt(identifier))
+        row: Optional["User"] = await db.scalar(await self._get_user_stmt(identifier))
         if not row or not verify_pw(password, row.password_hash):
             raise AuthError("invalid username/email or password")
         return row
@@ -79,35 +83,42 @@ class ApiKeyBackend:
     * The raw secret is never stored; verification is via BLAKE2b-256 digest.
     """
 
-    async def _get_key_stmt(self, digest: str) -> Select[tuple[ApiKey]]:
+    async def _get_key_stmt(self, digest: str) -> Select[tuple["ApiKey"]]:
+        from .orm.tables import ApiKey
+
         now = datetime.now(timezone.utc)
         return select(ApiKey).where(
             ApiKey.digest == digest,
             or_(ApiKey.valid_to.is_(None), ApiKey.valid_to > now),
         )
 
-    async def _get_service_key_stmt(self, digest: str) -> Select[tuple[ServiceKey]]:
+    async def _get_service_key_stmt(self, digest: str) -> Select[tuple["ServiceKey"]]:
+        from .orm.tables import ServiceKey
+
         now = datetime.now(timezone.utc)
         return select(ServiceKey).where(
             ServiceKey.digest == digest,
             or_(ServiceKey.valid_to.is_(None), ServiceKey.valid_to > now),
         )
 
-    async def _get_client_stmt(self) -> Select[tuple[Client]]:
+    async def _get_client_stmt(self) -> Select[tuple["Client"]]:
+        from .orm.tables import Client
+
         return select(Client).where(Client.is_active.is_(True))
 
     async def authenticate(
         self, db: AsyncSession, api_key: str
     ) -> tuple[Principal, str]:
         digest = ApiKey.digest_of(api_key)
-        key_row: Optional[ApiKey] = await db.scalar(await self._get_key_stmt(digest))
+
+        key_row: Optional["ApiKey"] = await db.scalar(await self._get_key_stmt(digest))
         if key_row and key_row.user:
             if not key_row.user.is_active:
                 raise AuthError("user is inactive")
             key_row.touch()
             return key_row.user, "user"
 
-        svc_row: Optional[ServiceKey] = await db.scalar(
+        svc_row: Optional["ServiceKey"] = await db.scalar(
             await self._get_service_key_stmt(digest)
         )
         if svc_row:
@@ -116,7 +127,7 @@ class ApiKeyBackend:
             svc_row.touch()
             return svc_row.service, "service"
 
-        clients: Iterable[Client] = await db.scalars(await self._get_client_stmt())
+        clients: Iterable["Client"] = await db.scalars(await self._get_client_stmt())
         for client in clients:
             if client.verify_secret(api_key):
                 return client, "client"

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_code.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_code.py
@@ -11,6 +11,7 @@ from autoapi.v3.specs import S, acol
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3.types import JSON, PgUUID, String, TZDateTime
 from autoapi.v3 import op_ctx
+from sqlalchemy.orm import Mapped
 from fastapi import HTTPException, status
 
 from ..rfc8414_metadata import ISSUER
@@ -24,20 +25,20 @@ class AuthCode(Base, Timestamped, UserMixin, TenantMixin):
     __tablename__ = "auth_codes"
     __table_args__ = ({"schema": "authn"},)
 
-    code: str = acol(storage=S(String(128), primary_key=True))
-    client_id: uuid.UUID = acol(
+    code: Mapped[str] = acol(storage=S(String(128), primary_key=True))
+    client_id: Mapped[uuid.UUID] = acol(
         storage=S(
             PgUUID(as_uuid=True),
             fk=ForeignKeySpec(target="authn.clients.id"),
             nullable=False,
         )
     )
-    redirect_uri: str = acol(storage=S(String(1000), nullable=False))
-    code_challenge: str | None = acol(storage=S(String, nullable=True))
-    nonce: str | None = acol(storage=S(String, nullable=True))
-    scope: str | None = acol(storage=S(String, nullable=True))
-    expires_at: dt.datetime = acol(storage=S(TZDateTime, nullable=False))
-    claims: dict | None = acol(storage=S(JSON, nullable=True))
+    redirect_uri: Mapped[str] = acol(storage=S(String(1000), nullable=False))
+    code_challenge: Mapped[str | None] = acol(storage=S(String, nullable=True))
+    nonce: Mapped[str | None] = acol(storage=S(String, nullable=True))
+    scope: Mapped[str | None] = acol(storage=S(String, nullable=True))
+    expires_at: Mapped[dt.datetime] = acol(storage=S(TZDateTime, nullable=False))
+    claims: Mapped[dict | None] = acol(storage=S(JSON, nullable=True))
 
     @op_ctx(alias="exchange", target="delete", arity="member")
     async def exchange(cls, ctx, obj):

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8628.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8628.py
@@ -13,13 +13,15 @@ from __future__ import annotations
 import re
 import secrets
 import string
-from typing import Final, Literal
+from typing import Final, Literal, TYPE_CHECKING
 
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .runtime_cfg import settings
-from .orm.tables import DeviceCode
+
+if TYPE_CHECKING:  # pragma: no cover
+    pass
 
 # Character set for user_code per RFC 8628 §6.1 (uppercase letters and digits)
 _USER_CODE_CHARSET: Final = string.ascii_uppercase + string.digits
@@ -65,6 +67,8 @@ async def approve_device_code(
     device_code: str, sub: str, tid: str, db: AsyncSession
 ) -> None:
     """Mark a device code as authorized (testing helper)."""
+
+    from .orm.tables import DeviceCode
 
     obj = await DeviceCode.handlers.read.core({"db": db, "obj_id": device_code})
     if obj:

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Final
+from typing import TYPE_CHECKING, Any, Dict, Final
 
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .orm.tables import PushedAuthorizationRequest
+if TYPE_CHECKING:  # pragma: no cover
+    pass
 
 DEFAULT_PAR_EXPIRY = 90  # seconds
 
@@ -30,6 +31,8 @@ async def store_par_request(
     expires_in: int = DEFAULT_PAR_EXPIRY,
 ) -> str:
     """Store *params* and return a unique ``request_uri``."""
+
+    from .orm.tables import PushedAuthorizationRequest
 
     request_uri = f"urn:ietf:params:oauth:request_uri:{uuid.uuid4()}"
     expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
@@ -49,6 +52,8 @@ async def store_par_request(
 async def get_par_request(request_uri: str, db: AsyncSession) -> Dict[str, Any] | None:
     """Retrieve parameters for *request_uri* if present and not expired."""
 
+    from .orm.tables import PushedAuthorizationRequest
+
     obj = await db.get(PushedAuthorizationRequest, request_uri)
     if not obj:
         return None
@@ -60,6 +65,8 @@ async def get_par_request(request_uri: str, db: AsyncSession) -> Dict[str, Any] 
 
 async def reset_par_store(db: AsyncSession) -> None:
     """Clear stored pushed authorization requests (test helper)."""
+
+    from .orm.tables import PushedAuthorizationRequest
 
     await db.execute(delete(PushedAuthorizationRequest))
     await db.commit()

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
@@ -204,7 +204,7 @@ class UserBound:  # membership rows
 # ────────── lifecycle --------------------------------------------------
 @declarative_mixin
 class Created:
-    created_at: dt.datetime = acol(
+    created_at: Mapped[dt.datetime] = acol(
         spec=ColumnSpec(
             storage=S(type_=TZDateTime, default=tzutcnow, nullable=False),
             field=F(py_type=dt.datetime),
@@ -215,7 +215,7 @@ class Created:
 
 @declarative_mixin
 class LastUsed:
-    last_used_at: dt.datetime | None = acol(
+    last_used_at: Mapped[dt.datetime | None] = acol(
         spec=ColumnSpec(
             storage=S(type_=TZDateTime, nullable=True, onupdate=tzutcnow),
             field=F(py_type=dt.datetime),

--- a/pkgs/standards/autoapi/autoapi/v3/tables/_base.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/_base.py
@@ -165,6 +165,8 @@ def _materialize_colspecs_to_sqla(cls) -> None:
 
 
 class Base(DeclarativeBase):
+    __allow_unmapped__ = True
+
     def __init_subclass__(cls, **kw):
         # 1) BEFORE SQLAlchemy maps: turn ColumnSpecs into real mapped_column(...)
         _materialize_colspecs_to_sqla(cls)

--- a/pkgs/standards/peagen/peagen/cli/commands/publickey.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/publickey.py
@@ -8,7 +8,7 @@ from typing import Optional
 import typer
 from httpx import HTTPError
 
-from peagen.plugins.cryptos import ParamikoCrypto
+from peagen.core import keys_core
 from peagen.core.publickey_core import login as core_login
 from peagen.defaults import DEFAULT_GATEWAY
 
@@ -40,7 +40,7 @@ def create(
 ) -> None:
     """Ensure a key-pair exists locally."""
     try:
-        ParamikoCrypto(key_dir=key_dir, passphrase=passphrase)
+        keys_core.create_keypair(key_dir, passphrase)
         typer.echo(f"✅  Created key-pair in {key_dir}")
     except Exception as exc:  # noqa: BLE001
         typer.echo(f"❌  {exc}", err=True)
@@ -74,8 +74,6 @@ def upload(
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
-
-    ParamikoCrypto(key_dir=key_dir, passphrase=passphrase)
 
     try:
         reply = core_login(

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from contextlib import contextmanager
 from pathlib import Path
 
+import os
+import anyio
 import httpx
 from autoapi_client import AutoAPIClient
 from autoapi.v2 import get_schema
@@ -25,28 +27,23 @@ from peagen.defaults import DEFAULT_GATEWAY
 from peagen.orm import DeployKey
 from peagen.plugins import PluginManager
 
-# ───────────────────────── cryptography layer ───────────────────────────
-from peagen.plugins.cryptos import ParamikoCrypto, CryptoBase
+from swarmauri_core.keys.types import KeyAlg, KeyClass, KeySpec, ExportPolicy
+from swarmauri_core.crypto.types import KeyUse
 
 
-# -----------------------------------------------------------------------#
-# Internal helpers
-# -----------------------------------------------------------------------#
-def _get_crypto(
-    key_dir: str | Path | None = None,
-    passphrase: str | None = None,
-) -> CryptoBase:
+def _get_key_provider():
+    """Return a key provider plugin instance.
+
+    Falls back to ``SshKeyProvider`` when no plugin is configured.
     """
-    Resolve a `CryptoBase` provider through the plugin manager.
-    Fallback ➜ `ParamikoCrypto` when no plugin is configured.
-    """
-    cfg = resolve_cfg()  # helper loads ~/.peagen.toml
+    cfg = resolve_cfg()
     pm = PluginManager(cfg)
     try:
-        crypto_cls = pm.get("cryptos")  # user-supplied plugin
+        return pm.get("key_providers")
     except KeyError:
-        crypto_cls = ParamikoCrypto  # built-in default
-    return crypto_cls(key_dir=key_dir, passphrase=passphrase)
+        from swarmauri_keyprovider_ssh import SshKeyProvider
+
+        return SshKeyProvider()
 
 
 @contextmanager
@@ -74,8 +71,36 @@ def create_keypair(
     -------
     dict  { "fingerprint": str, "public_key": str }
     """
-    drv = _get_crypto(key_dir, passphrase)
-    return {"fingerprint": drv.fingerprint(), "public_key": drv.public_key_str()}
+    key_dir = Path(key_dir or Path.home() / ".peagen" / "keys")
+    kp = _get_key_provider()
+
+    priv_path = key_dir / "ssh-private"
+    pub_path = key_dir / "ssh-public"
+    key_dir.mkdir(parents=True, exist_ok=True)
+
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        label="peagen",
+    )
+
+    if priv_path.exists() and pub_path.exists():
+        material = priv_path.read_bytes()
+        public = pub_path.read_bytes()
+        ref = anyio.run(kp.import_key, spec, material, public=public)
+    else:
+        ref = anyio.run(kp.create_key, spec)
+        if ref.material:
+            priv_path.write_bytes(ref.material)
+            os.chmod(priv_path, 0o600)
+        if ref.public:
+            pub_path.write_bytes(ref.public)
+
+    fingerprint = ref.tags.get("ssh_fingerprint", getattr(ref, "fingerprint", ""))
+    public_key = (ref.public or b"").decode().strip()
+    return {"fingerprint": fingerprint, "public_key": public_key}
 
 
 def upload_public_key(
@@ -83,14 +108,14 @@ def upload_public_key(
     passphrase: str | None = None,
     gateway_url: str = DEFAULT_GATEWAY,
 ) -> dict:
-    drv = _get_crypto(key_dir, passphrase)
+    info = create_keypair(key_dir, passphrase)
     SCreateIn = _schema("create")
     SRead = _schema("read")
 
     with _rpc(gateway_url) as rpc:
         res = rpc.call(
             "DeployKeys.create",
-            params=SCreateIn(key=drv.public_key_str()),
+            params=SCreateIn(key=info["public_key"]),
             out_schema=SRead,
         )
     return res.model_dump()

--- a/pkgs/standards/peagen/peagen/core/publickey_core.py
+++ b/pkgs/standards/peagen/peagen/core/publickey_core.py
@@ -20,7 +20,7 @@ from autoapi.v2 import get_schema  # ← schema helper
 from peagen.orm import PublicKey  # ORM resource
 
 from peagen.defaults import DEFAULT_GATEWAY, DEFAULT_SUPER_USER_ID
-from peagen.plugins.cryptos import ParamikoCrypto
+from peagen.core import keys_core
 
 __all__ = ["login"]
 
@@ -48,8 +48,8 @@ def login(
         JSON-RPC error returned by the gateway.
     """
     # 1 ─ ensure local SSH key-pair
-    drv = ParamikoCrypto(key_dir=key_dir, passphrase=passphrase)
-    public_key = drv.public_key_str()  # returns single-line OpenSSH key
+    kp = keys_core.create_keypair(key_dir, passphrase)
+    public_key = kp["public_key"]
 
     # 2 ─ build request/response schemas dynamically
     SCreate = _schema("create")

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -7,6 +7,7 @@ from types import ModuleType
 from typing import Any, Dict, Optional
 
 from peagen.errors import InvalidPluginSpecError
+from swarmauri_base.keys import KeyProviderBase
 
 # ---------------------------------------------------------------------------
 # Config – group key → (entry-point group string, expected base class)
@@ -30,6 +31,7 @@ GROUPS = {
     # keys and secrets
     "cryptos": ("peagen.plugins.cryptos", object),
     "secrets_drivers": ("peagen.plugins.secret_drivers", object),
+    "key_providers": ("swarmauri.key_providers", KeyProviderBase),
     # template sets remain in the top-level package
     "template_sets": ("peagen.template_sets", None),
 }
@@ -191,6 +193,11 @@ class PluginManager:
             "section": "cryptos",
             "items": "adapters",
             "default": "default_crypto",
+        },
+        "key_providers": {
+            "section": "key_providers",
+            "items": "providers",
+            "default": "default_provider",
         },
     }
 


### PR DESCRIPTION
## Summary
- add `key_providers` plugin group and configuration
- load key providers via PluginManager and default to `SshKeyProvider`
- update public key helper and CLI to use key provider plugin
- fix ORM annotations and defer imports to resolve SQLAlchemy mapping errors

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto-authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto-authn ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: multiple test failures in plugin manager and CLI)*
- `uv run --directory pkgs/standards/auto_authn --package auto-authn pytest` *(fails: missing dependency 'nest_asyncio' and other import errors)*

------
https://chatgpt.com/codex/tasks/task_b_68adf051ed0c8331859ad0954b915fa5