### PR TITLE
feat(peagen): wrap keys via kms

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/kms.py
+++ b/pkgs/standards/peagen/peagen/gateway/kms.py
@@ -1,0 +1,43 @@
+"""Utilities for wrapping key material with an external KMS."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import httpx
+
+from .runtime_cfg import settings
+
+
+async def wrap_key_with_kms(key: str) -> str:
+    """Return KMS-wrapped *key* if a KMS endpoint is configured.
+
+    Parameters
+    ----------
+    key:
+        The raw key material to wrap.
+
+    Returns
+    -------
+    str
+        The wrapped key returned by the KMS or the original key when no KMS is
+        configured or the request fails.
+    """
+
+    kms_url = settings.kms_wrap_url
+    if not kms_url:
+        return key
+
+    payload: dict[str, Any] = {
+        "key_material_b64": base64.b64encode(key.encode()).decode()
+    }
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(kms_url, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("wrapped_key_b64", key)
+    except Exception:
+        # Fail open – loggers in calling code can capture details if desired.
+        return key

--- a/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
+++ b/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
@@ -33,13 +33,20 @@ class Settings(BaseSettings):
     pg_user: Optional[str] = Field(default=os.environ.get("PG_USER"))
     pg_pass: Optional[str] = Field(default=os.environ.get("PG_PASS"))
 
-
     # ─────────────────────────── AuthN ──────────────────────────────────
 
-    authn_base_url: Optional[str] = Field(default=os.environ.get("AUTHN_BASE_URL", "https://authn.peagen.com"))  # e.g. http://authn:8080/
-    authn_timeout:   Optional[float] = Field(default=os.environ.get("AUTHN_TIMEOUT_SEC", 0.5))         # seconds
-    authn_cache_ttl: Optional[int] = Field(default=int(os.environ.get("AUTHN_CACHE_TTL", 30)))        # seconds
-    authn_cache_size: Optional[int] = Field(default=int(os.environ.get("AUTHN_CACHE_SIZE", 5000)))       # entries
+    authn_base_url: Optional[str] = Field(
+        default=os.environ.get("AUTHN_BASE_URL", "https://authn.peagen.com")
+    )  # e.g. http://authn:8080/
+    authn_timeout: Optional[float] = Field(
+        default=os.environ.get("AUTHN_TIMEOUT_SEC", 0.5)
+    )  # seconds
+    authn_cache_ttl: Optional[int] = Field(
+        default=int(os.environ.get("AUTHN_CACHE_TTL", 30))
+    )  # seconds
+    authn_cache_size: Optional[int] = Field(
+        default=int(os.environ.get("AUTHN_CACHE_SIZE", 5000))
+    )  # entries
 
     @property
     def pg_dsn(self) -> str:
@@ -60,6 +67,7 @@ class Settings(BaseSettings):
     # ───────── Other global settings ─────────
     jwt_secret: str = Field(os.environ.get("JWT_SECRET", "insecure-dev-secret"))
     log_level: str = Field(os.environ.get("LOG_LEVEL", "INFO"))
+    kms_wrap_url: Optional[str] = Field(default=os.environ.get("KMS_WRAP_URL"))
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/peagen/tests/unit/test_kms_wrap_keys.py
+++ b/pkgs/standards/peagen/tests/unit/test_kms_wrap_keys.py
@@ -1,0 +1,81 @@
+from types import ModuleType, SimpleNamespace
+import sys
+
+import pytest
+
+from peagen.orm.keys import DeployKey, GPGKey, PublicKey
+
+
+@pytest.mark.asyncio
+async def test_public_key_wrap(monkeypatch):
+    called = {}
+
+    async def fake_wrap(key: str) -> str:
+        called["key"] = key
+        return "wrapped"
+
+    gw_pkg = ModuleType("peagen.gateway")
+    gw_pkg.__path__ = []  # mark as package
+    sys.modules["peagen.gateway"] = gw_pkg
+    kms_mod = ModuleType("peagen.gateway.kms")
+    kms_mod.wrap_key_with_kms = fake_wrap
+    sys.modules["peagen.gateway.kms"] = kms_mod
+
+    params = SimpleNamespace(public_key="pub")
+    ctx = {"env": SimpleNamespace(params=params)}
+    await PublicKey._pre_create(ctx)
+    assert called["key"] == "pub"
+    assert params.public_key == "wrapped"
+
+
+@pytest.mark.asyncio
+async def test_gpg_key_wrap(monkeypatch):
+    called = {}
+
+    async def fake_wrap(key: str) -> str:
+        called["key"] = key
+        return "wrapped"
+
+    gw_pkg = ModuleType("peagen.gateway")
+    gw_pkg.__path__ = []
+    sys.modules["peagen.gateway"] = gw_pkg
+    kms_mod = ModuleType("peagen.gateway.kms")
+    kms_mod.wrap_key_with_kms = fake_wrap
+    sys.modules["peagen.gateway.kms"] = kms_mod
+
+    params = SimpleNamespace(gpg_key="gpg")
+    ctx = {"env": SimpleNamespace(params=params)}
+    await GPGKey._pre_create(ctx)
+    assert called["key"] == "gpg"
+    assert params.gpg_key == "wrapped"
+
+
+@pytest.mark.asyncio
+async def test_deploy_key_wrap(monkeypatch):
+    called = {}
+
+    async def fake_wrap(key: str) -> str:
+        called["key"] = key
+        return "wrapped"
+
+    class DummyPGPKey:
+        fingerprint = "FP"
+
+        def parse(self, data: str) -> None:
+            assert data == "pub"
+
+    gw_pkg = ModuleType("peagen.gateway")
+    gw_pkg.__path__ = []
+    gw_pkg.log = SimpleNamespace(info=lambda *args, **kwargs: None)
+    sys.modules["peagen.gateway"] = gw_pkg
+    kms_mod = ModuleType("peagen.gateway.kms")
+    kms_mod.wrap_key_with_kms = fake_wrap
+    sys.modules["peagen.gateway.kms"] = kms_mod
+    monkeypatch.setattr("pgpy.PGPKey", DummyPGPKey)
+
+    params = SimpleNamespace(public_key="pub")
+    ctx = {"env": SimpleNamespace(params=params)}
+    await DeployKey._pre_create(ctx)
+    assert called["key"] == "pub"
+    assert params.public_key == "wrapped"
+    assert ctx["fingerprint"] == "FP"


### PR DESCRIPTION
## Summary
- add runtime setting for KMS key wrapping
- wrap public, deploy, and GPG keys via KMS on creation
- cover new KMS wrapping hooks with unit tests

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/gateway/kms.py peagen/gateway/runtime_cfg.py peagen/orm/keys.py tests/unit/test_kms_wrap_keys.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/kms.py peagen/gateway/runtime_cfg.py peagen/orm/keys.py tests/unit/test_kms_wrap_keys.py --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest tests/unit/test_kms_wrap_keys.py`


------
https://chatgpt.com/codex/tasks/task_b_68ae04e9c7b083318aaef730d7ba0d93