### PR TITLE
feat: add in-memory key provider and gateway config

### DIFF
--- a/infra/peagen/.gw.peagen.toml
+++ b/infra/peagen/.gw.peagen.toml
@@ -57,3 +57,9 @@ owner = "${OWNER}"
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"
 
+# ─────────────────────────── Key Providers ─────────────────────────────
+[key_providers]
+default_provider = "InMemoryKeyProvider"
+
+[key_providers.providers.InMemoryKeyProvider]
+# no configuration needed for in-memory provider

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -87,6 +87,7 @@ members = [
     "standards/swarmauri_keyprovider_file",
     "standards/swarmauri_keyproviders_mirrored",
     "standards/swarmauri_keyprovider_hierarchical",
+    "standards/swarmauri_keyprovider_inmemory",
     "swarmauri_certs_pkcs11",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
@@ -282,6 +283,7 @@ swarmauri_cert_acme = { workspace = true }
 swarmauri_keyprovider_file = { workspace = true }
 swarmauri_keyproviders_mirrored = { workspace = true }
 swarmauri_keyprovider_hierarchical = { workspace = true }
+swarmauri_keyprovider_inmemory = { workspace = true }
 swarmauri_signing_hmac = { workspace = true }
 swarmauri_signing_ecdsa = { workspace = true }
 swarmauri_signing_ca = { workspace = true }

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/LICENSE
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
@@ -1,0 +1,10 @@
+# swarmauri_keyprovider_inmemory
+
+An in-memory key provider plugin for Swarmauri. It stores all generated or imported keys only in volatile memory, ensuring no key material is written to disk.
+
+## Features
+- Supports symmetric and asymmetric key classes
+- Create, import, rotate, and destroy keys
+- Random bytes generation and HKDF derivation
+
+This provider is intended for ephemeral environments where persistence is not desired.

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/pyproject.toml
@@ -1,0 +1,63 @@
+[project]
+name = "swarmauri_keyprovider_inmemory"
+version = "0.1.0"
+description = "In-memory key provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+    "example: Example usage tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.key_providers']
+InMemoryKeyProvider = "swarmauri_keyprovider_inmemory.InMemoryKeyProvider:InMemoryKeyProvider"

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/swarmauri_keyprovider_inmemory/InMemoryKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/swarmauri_keyprovider_inmemory/InMemoryKeyProvider.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, Optional, Tuple, Literal
+import secrets
+import hashlib
+import hmac
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.crypto.types import KeyRef, KeyType, ExportPolicy
+from swarmauri_core.keys.types import KeySpec, KeyClass
+
+
+class InMemoryKeyProvider(KeyProviderBase):
+    """Simple in-memory key provider for testing or ephemeral usage."""
+
+    type: Literal["InMemoryKeyProvider"] = "InMemoryKeyProvider"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._store: Dict[str, Dict[int, KeyRef]] = {}
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {
+            "class": ("sym", "asym"),
+            "algs": (),
+            "features": ("create", "import", "rotate"),
+        }
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        kid = secrets.token_hex(8)
+        version = 1
+        material = secrets.token_bytes(32)
+        ref = KeyRef(
+            kid=kid,
+            version=version,
+            type=(
+                KeyType.SYMMETRIC
+                if spec.klass == KeyClass.symmetric
+                else KeyType.OPAQUE
+            ),
+            uses=tuple(spec.uses),
+            export_policy=spec.export_policy,
+            material=(material if spec.export_policy != ExportPolicy.NONE else None),
+            tags={"label": spec.label or "", **(spec.tags or {})},
+        )
+        self._store.setdefault(kid, {})[version] = ref
+        return ref
+
+    async def import_key(
+        self,
+        spec: KeySpec,
+        material: bytes,
+        *,
+        public: Optional[bytes] = None,
+    ) -> KeyRef:
+        kid = secrets.token_hex(8)
+        version = 1
+        ref = KeyRef(
+            kid=kid,
+            version=version,
+            type=(
+                KeyType.SYMMETRIC
+                if spec.klass == KeyClass.symmetric
+                else KeyType.OPAQUE
+            ),
+            uses=tuple(spec.uses),
+            export_policy=spec.export_policy,
+            material=(material if spec.export_policy != ExportPolicy.NONE else None),
+            public=public,
+            tags={"label": spec.label or "", **(spec.tags or {})},
+        )
+        self._store.setdefault(kid, {})[version] = ref
+        return ref
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        bucket = self._store.get(kid)
+        if not bucket:
+            raise KeyError(f"Unknown kid: {kid}")
+        latest = max(bucket)
+        base = bucket[latest]
+        material = secrets.token_bytes(len(base.material or b"\x00" * 32))
+        version = latest + 1
+        ref = KeyRef(
+            kid=kid,
+            version=version,
+            type=base.type,
+            uses=base.uses,
+            export_policy=base.export_policy,
+            material=(material if base.export_policy != ExportPolicy.NONE else None),
+            public=base.public,
+            tags=base.tags,
+            uri=base.uri,
+        )
+        bucket[version] = ref
+        return ref
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        bucket = self._store.get(kid)
+        if not bucket:
+            return False
+        if version is None:
+            del self._store[kid]
+            return True
+        bucket.pop(version, None)
+        if not bucket:
+            del self._store[kid]
+        return True
+
+    async def get_key(
+        self,
+        kid: str,
+        version: Optional[int] = None,
+        *,
+        include_secret: bool = False,
+    ) -> KeyRef:
+        bucket = self._store[kid]
+        v = version or max(bucket)
+        return bucket[v]
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        bucket = self._store.get(kid)
+        if not bucket:
+            raise KeyError(f"Unknown kid: {kid}")
+        return tuple(sorted(bucket.keys()))
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        raise NotImplementedError("JWK export not supported")
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        raise NotImplementedError("JWKS export not supported")
+
+    async def random_bytes(self, n: int) -> bytes:
+        return secrets.token_bytes(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        """Derive key material using HKDF-SHA256."""
+        prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+        t = b""
+        okm = b""
+        counter = 1
+        while len(okm) < length:
+            t = hmac.new(prk, t + info + bytes([counter]), hashlib.sha256).digest()
+            okm += t
+            counter += 1
+        return okm[:length]

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/swarmauri_keyprovider_inmemory/__init__.py
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/swarmauri_keyprovider_inmemory/__init__.py
@@ -1,0 +1,3 @@
+from .InMemoryKeyProvider import InMemoryKeyProvider
+
+__all__ = ["InMemoryKeyProvider"]

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/tests/unit/test_inmemory_provider_unit.py
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/tests/unit/test_inmemory_provider_unit.py
@@ -1,0 +1,24 @@
+import pytest
+from swarmauri_keyprovider_inmemory import InMemoryKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyClass, KeyAlg, ExportPolicy, KeyUse
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_and_get() -> None:
+    provider = InMemoryKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+    ref = await provider.create_key(spec)
+    fetched = await provider.get_key(ref.kid)
+    assert fetched.kid == ref.kid
+    assert fetched.material == ref.material
+
+
+@pytest.mark.unit
+def test_type() -> None:
+    assert InMemoryKeyProvider().type == "InMemoryKeyProvider"


### PR DESCRIPTION
## Summary
- add InMemoryKeyProvider plugin that keeps keys in memory only
- default gateway configuration to use the in-memory provider

## Testing
- `uv run --directory standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory ruff format .`
- `uv run --directory standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory ruff check . --fix`
- `uv run --directory standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aebc1a1fb48331864ee895468d7337