### PR TITLE
Add tests for AutoAPI v3 schema examples and spec housing

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_openapi_schema_examples_presence.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_openapi_schema_examples_presence.py
@@ -1,0 +1,79 @@
+import pytest
+from autoapi.v3 import AutoApp, Base
+from autoapi.v3.engine.shortcuts import mem
+from autoapi.v3.orm.mixins import GUIDPk
+from autoapi.v3.types import App
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, String
+
+
+class Widget(Base, GUIDPk):
+    __tablename__ = "widgets_example_presence"
+    name = Column(String, nullable=False, info={"autoapi": {"examples": ["foo"]}})
+
+
+def _resolve_schema(spec, schema):
+    if "$ref" in schema:
+        ref = schema["$ref"].split("/")[-1]
+        return spec["components"]["schemas"][ref]
+    if "anyOf" in schema:
+        return _resolve_schema(spec, schema["anyOf"][0])
+    if "items" in schema:
+        item = _resolve_schema(spec, schema["items"])
+        schema["items"] = item
+        if "examples" not in schema and "examples" in item:
+            schema["examples"] = [item["examples"][0]]
+    return schema
+
+
+@pytest.mark.asyncio
+@pytest.mark.i9n
+async def test_openapi_examples_and_schemas_present(db_mode):
+    fastapi_app = App()
+    engine = mem() if db_mode == "async" else mem(async_=False)
+    api = AutoApp(engine=engine)
+    api.include_model(Widget)
+    if db_mode == "async":
+        await api.initialize()
+    else:
+        api.initialize()
+    api.mount_jsonrpc()
+    fastapi_app.include_router(api.router)
+
+    transport = ASGITransport(app=fastapi_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        spec = (await client.get("/openapi.json")).json()
+
+    path = f"/{Widget.__name__.lower()}"
+    create_req = spec["paths"][path]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    create_resp = spec["paths"][path]["post"]["responses"]["201"]["content"][
+        "application/json"
+    ]["schema"]
+    create_req = _resolve_schema(spec, create_req)
+    create_resp = _resolve_schema(spec, create_resp)
+    assert create_req["properties"]["name"]["examples"][0] == "foo"
+    assert create_resp["properties"]["name"]["examples"][0] == "foo"
+
+    expected = {
+        "WidgetClearResponse",
+        "WidgetCreateRequest",
+        "WidgetCreateResponse",
+        "WidgetDeleteResponse",
+        "WidgetListResponse",
+        "WidgetReadResponse",
+        "WidgetReplaceRequest",
+        "WidgetReplaceResponse",
+        "WidgetUpdateRequest",
+        "WidgetUpdateResponse",
+    }
+    assert expected <= set(spec["components"]["schemas"])
+
+    assert hasattr(api.schemas, "Widget")
+    widget_ns = getattr(api.schemas, "Widget")
+    for alias in ["create", "read", "update", "replace", "delete", "list", "clear"]:
+        assert hasattr(widget_ns, alias)
+        op_ns = getattr(widget_ns, alias)
+        assert hasattr(op_ns, "in_")
+        assert hasattr(op_ns, "out")

--- a/pkgs/standards/autoapi/tests/unit/test_schema_spec_presence.py
+++ b/pkgs/standards/autoapi/tests/unit/test_schema_spec_presence.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel
+from autoapi.v3.app.shortcuts import deriveApp
+from autoapi.v3.api.shortcuts import deriveApi
+from autoapi.v3.table.shortcuts import defineTableSpec
+from autoapi.v3.orm.mixins import GUIDPk
+from autoapi.v3.orm.tables import Base
+from sqlalchemy import Column, String
+from uuid import uuid4
+
+
+class ExSchema(BaseModel):
+    name: str
+
+
+AppCls = deriveApp(schemas=[ExSchema])
+ApiCls = deriveApi(schemas=[ExSchema])
+
+
+def test_app_houses_schemas():
+    assert ExSchema in AppCls.SCHEMAS
+
+
+def test_api_houses_schemas():
+    assert ExSchema in ApiCls.SCHEMAS
+
+
+def test_table_houses_schemas():
+    Base.metadata.clear()
+
+    Spec = defineTableSpec(schemas=[ExSchema])
+
+    class Model(Spec, Base, GUIDPk):
+        __tablename__ = f"schema_spec_model_{uuid4().hex}"
+        name = Column(String)
+
+    assert ExSchema in Model.SCHEMAS


### PR DESCRIPTION
## Summary
- add integration test ensuring openapi.json exposes examples and expected schemas for sync and async modes
- verify schema registration on App, API, and Table spec classes

## Testing
- `uv run --directory pkgs/standards --package autoapi ruff check autoapi/tests/i9n/test_openapi_schema_examples_presence.py autoapi/tests/unit/test_schema_spec_presence.py --fix`
- `uv run --directory pkgs/standards --package autoapi pytest autoapi/tests/i9n/test_openapi_schema_examples_presence.py autoapi/tests/unit/test_schema_spec_presence.py`


------
https://chatgpt.com/codex/tasks/task_b_68b8469ad7b08331970f860120e80ee2