### PR TITLE
docs: refresh Shamir MRE README and example test

### DIFF
--- a/pkgs/standards/swarmauri_mre_crypto_shamir/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_shamir/README.md
@@ -21,16 +21,85 @@
 Shamir Secret Sharing based multi-recipient encryption (MRE) provider for the Swarmauri framework. The provider splits an AES-256-GCM content encryption key using Shamir's threshold scheme and distributes shares to recipients.
 
 ## Features
+
 - AES-256-GCM payload encryption
 - Threshold k-of-n key sharing via Shamir secret sharing
 - Envelope rewrapping with optional payload rotation
+- Optional authenticated data (AAD) handling
 
 ## Extras
+
 The plugin supports optional canonicalization extras:
+
 - `cbor` – enables CBOR canonicalization via `cbor2`
 
 ## Installation
-This package is part of the Swarmauri standards collection and is typically installed as part of the `swarmauri-sdk` workspace.
+
+Choose the tool that matches your workflow:
+
+```bash
+# pip
+pip install swarmauri_mre_crypto_shamir
+
+# Poetry
+poetry add swarmauri_mre_crypto_shamir
+
+# uv (project dependency)
+uv add swarmauri_mre_crypto_shamir
+
+# uv (one-off virtual environment)
+uv pip install swarmauri_mre_crypto_shamir
+```
+
+Install extras, such as CBOR canonicalization support, with `swarmauri_mre_crypto_shamir[cbor]`.
+
+## Quickstart
+
+`ShamirMreCrypto` encrypts a payload with a fresh AES-256-GCM content encryption key, splits the key into Shamir shares, and stores the encrypted payload and shares in a multi-recipient envelope. Provide a threshold with `opts["threshold_k"]` (defaults to a simple majority) to control how many shares are required to decrypt.
+
+```python
+import asyncio
+
+from swarmauri_mre_crypto_shamir import ShamirMreCrypto
+
+
+async def main() -> None:
+    provider = ShamirMreCrypto()
+
+    recipients = [
+        {"kid": "alice"},
+        {"kid": "bob"},
+        {"kid": "carol"},
+    ]
+
+    plaintext = b"Secret launch codes"
+
+    envelope = await provider.encrypt_for_many(
+        recipients,
+        plaintext,
+        opts={"threshold_k": 2},
+    )
+
+    print("Mode:", envelope["mode"])
+    print("Recipients:", [entry["id"] for entry in envelope["recipients"]])
+    print(
+        "Threshold:",
+        int.from_bytes(envelope["shared"]["threshold_k"], "big"),
+    )
+
+    recovered = await provider.open_for_many(
+        [{"kid": "alice"}, {"kid": "carol"}],
+        envelope,
+    )
+
+    assert recovered == plaintext
+    print("Recovered plaintext:", recovered.decode("utf-8"))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
 
 ## License
+
 Apache-2.0

--- a/pkgs/standards/swarmauri_mre_crypto_shamir/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_shamir/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_mre_crypto_shamir/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_mre_crypto_shamir/tests/test_readme_example.py
@@ -1,0 +1,33 @@
+"""Ensure the README quickstart stays runnable."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parent.parent / "README.md"
+
+
+@pytest.mark.example
+def test_quickstart_example_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    """Execute the README quickstart example verbatim."""
+
+    readme = README_PATH.read_text(encoding="utf-8")
+    match = re.search(r"```python\n(?P<code>.*?)```", readme, re.DOTALL)
+    assert match is not None, "Could not locate python example in README.md"
+
+    code = match.group("code").strip()
+
+    original_sys_path = list(sys.path)
+    sys.path.insert(0, str(README_PATH.parent))
+    try:
+        exec(compile(code, str(README_PATH), "exec"), {"__name__": "__main__"})
+    finally:
+        sys.path[:] = original_sys_path
+
+    captured = capsys.readouterr()
+    assert "Recovered plaintext:" in captured.out


### PR DESCRIPTION
## Summary
- expand the Shamir MRE README with installation commands and a runnable quickstart example
- register an `example` pytest marker and add a test that executes the README code block

## Testing
- uv run --directory pkgs/standards/swarmauri_mre_crypto_shamir --package swarmauri_mre_crypto_shamir ruff format .
- uv run --directory pkgs/standards/swarmauri_mre_crypto_shamir --package swarmauri_mre_crypto_shamir ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_mre_crypto_shamir --package swarmauri_mre_crypto_shamir pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78e39fcc83319eba9763fca573aa