### PR TITLE
docs: refresh swarmauri_signing_ssh README and add example test

### DIFF
--- a/pkgs/standards/swarmauri_signing_ssh/README.md
+++ b/pkgs/standards/swarmauri_signing_ssh/README.md
@@ -22,34 +22,134 @@ An OpenSSH-based signer implementing the `ISigning` interface for detached
 signatures over raw bytes and canonicalized envelopes.
 
 Features:
-- JSON canonicalization (always available)
-- Optional CBOR canonicalization via `cbor2`
-- Detached signatures using OpenSSH `ssh-keygen -Y`
+- Detached signatures powered by OpenSSH `ssh-keygen -Y` for Ed25519, RSA and
+  ECDSA keys.
+- Accepts private keys from filesystem paths or in-memory PEM blobs.
+- JSON canonicalization built in with optional CBOR canonicalization via
+  `cbor2`.
+- Envelope helpers for canonicalized signing and verification workflows.
+
+## Requirements
+
+- OpenSSH `ssh-keygen` (v8.2 or newer with `-Y` support) must be available on
+  `PATH`.
+- Install the optional `cbor` extra (`swarmauri_signing_ssh[cbor]`) to enable
+  CBOR canonicalization.
 
 ## Installation
+
+### pip
 
 ```bash
 pip install swarmauri_signing_ssh
 ```
 
+Enable CBOR canonicalization when desired:
+
+```bash
+pip install "swarmauri_signing_ssh[cbor]"
+```
+
+### uv
+
+```bash
+uv add swarmauri_signing_ssh
+```
+
+```bash
+uv add "swarmauri_signing_ssh[cbor]"
+```
+
+### Poetry
+
+```bash
+poetry add swarmauri_signing_ssh
+```
+
+```bash
+poetry add swarmauri_signing_ssh -E cbor
+```
+
 ## Usage
 
-```python
+### Supported key references
+
+Provide the signer with a `KeyRef` dictionary:
+
+- `{"kind": "path", "priv": "/path/to/id_ed25519", "identity": "optional"}`
+  references a private key on disk.
+- `{"kind": "pem", "priv": "-----BEGIN OPENSSH PRIVATE KEY-----..."}`
+  accepts an OpenSSH private key as text/bytes. The key material is written to a
+  secure temporary file for signing.
+
+The signer derives the corresponding public key line, fingerprint (`kid`) and
+algorithm token automatically.
+
+### Verification options
+
+- Pass one or more OpenSSH public key lines via `opts["pubkeys"]` when calling
+  `verify_bytes` or `verify_envelope`. Verification fails immediately when the
+  list is missing or empty.
+- Override the namespace used by `ssh-keygen -Y` through `opts["namespace"]`
+  (defaults to `"file"`).
+- Supply the expected signer identity with `opts["identity"]`. Identities
+  default to `signer{i}` based on index order.
+- Restrict acceptable signatures via the `require` mapping. Supported keys are
+  `"algs"`, `"kids"` and `"min_signers"`.
+
+### README example: sign and verify an SSH signature
+
+```python title="README example: sign and verify an SSH signature"
 import asyncio
+import subprocess
+import tempfile
+from pathlib import Path
+
 from swarmauri_signing_ssh import SshEnvelopeSigner
 
-async def main():
-    signer = SshEnvelopeSigner()
-    key = {"kind": "path", "priv": "/path/to/id_ed25519"}
-    payload = b"hello"
-    sigs = await signer.sign_bytes(key, payload)
-    pub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA..."
-    ok = await signer.verify_bytes(payload, sigs, opts={"pubkeys": [pub]})
-    print(ok)
 
-asyncio.run(main())
+async def main() -> bool:
+    signer = SshEnvelopeSigner()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        priv_path = tmpdir_path / "id_ed25519"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(priv_path)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        pubkey_line = priv_path.with_suffix(".pub").read_text(encoding="utf-8").strip()
+
+        key = {"kind": "path", "priv": str(priv_path), "identity": "readme-demo"}
+        payload = b"hello ssh signatures"
+
+        signatures = await signer.sign_bytes(key, payload)
+        return await signer.verify_bytes(
+            payload,
+            signatures,
+            opts={"pubkeys": [pubkey_line], "identity": "readme-demo"},
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - README execution path
+    print(asyncio.run(main()))
 ```
+
+Running the script prints `True` once verification succeeds.
+
+### Envelope workflows
+
+Use `sign_envelope` / `verify_envelope` alongside `canonicalize_envelope` to
+operate on structured payloads. JSON canonicalization is always available;
+enable the `cbor` extra to emit canonical CBOR bytes.
+
+RSA keys default to `sha256` hashing but accept `hashalg="sha512"` via either
+the key reference or `opts`. All signatures are detached (`features` include
+`"detached_only"`), and multiple signatures can be verified in a single call.
 
 ## Entry Point
 
-The signer registers under the `swarmauri.signings` entry point as `SshEnvelopeSigner`.
+The signer registers under the `swarmauri.signings` entry point as
+`SshEnvelopeSigner`.

--- a/pkgs/standards/swarmauri_signing_ssh/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ssh/pyproject.toml
@@ -38,6 +38,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: README-backed usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_ssh/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_ssh/tests/example/test_readme_example.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import textwrap
+from typing import Awaitable, Callable, cast
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+_BLOCK_HEADER = '```python title="README example: sign and verify an SSH signature"'
+
+
+def _extract_readme_example() -> str:
+    content = README_PATH.read_text(encoding="utf-8")
+    in_block = False
+    lines: list[str] = []
+    for line in content.splitlines():
+        if not in_block and line.strip() == _BLOCK_HEADER:
+            in_block = True
+            continue
+        if in_block:
+            if line.strip().startswith("```"):
+                break
+            lines.append(line)
+    if not lines:
+        raise AssertionError("README example block was not found")
+    return textwrap.dedent("\n".join(lines))
+
+
+@pytest.mark.asyncio
+@pytest.mark.example
+async def test_readme_example_executes() -> None:
+    code = _extract_readme_example()
+    module_globals: dict[str, object] = {"__name__": "__readme__"}
+    exec(compile(code, str(README_PATH), "exec"), module_globals)  # noqa: S102
+    main_obj = module_globals.get("main")
+    assert callable(main_obj), "README example must define a callable 'main'"
+    main = cast(Callable[[], Awaitable[bool]], main_obj)
+
+    result = await main()
+    assert result is True


### PR DESCRIPTION
## Summary
- expand the swarmauri_signing_ssh README with installation options, key/verification details, and a runnable example
- add a pytest that extracts and executes the README example and register an `example` marker

## Testing
- uv run --directory pkgs/standards/swarmauri_signing_ssh --package swarmauri_signing_ssh ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signing_ssh --package swarmauri_signing_ssh pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78dac8208331a77377e143ece99b