### PR TITLE
Document file storage adapter behavior and test README

### DIFF
--- a/pkgs/standards/swarmauri_storage_file/README.md
+++ b/pkgs/standards/swarmauri_storage_file/README.md
@@ -18,21 +18,77 @@
 
 # Swarmauri File Storage Adapter
 
-Filesystem-based storage adapter for Peagen that stores artifacts on the local disk.
+Filesystem-based storage adapter for Peagen that stores binary artifacts on the
+local disk.
+
+## Features
+
+- Resolves and prepares the configured ``output_dir`` on instantiation so
+  uploads can run without additional filesystem setup.
+- Supports an optional ``prefix`` to scope all keys inside a nested directory
+  tree while keeping the same adapter instance.
+- ``upload`` writes files atomically by copying into a temporary file before an
+  atomic rename, ensuring partially written data is never observed.
+- ``download`` returns a :class:`io.BytesIO` handle positioned at the start of
+  the stored content for immediate consumption by downstream tooling.
+- Convenience helpers such as ``upload_dir``, ``download_dir``, ``iter_prefix``
+  and ``from_uri`` mirror the behavior of :class:`pathlib.Path` operations and
+  make it easy to bulk transfer artifacts.
+- ``root_uri`` exposes the workspace as a ``file://`` URI which is used when
+  constructing the URIs returned by ``upload``.
 
 ## Installation
 
+Install the package with your preferred Python packaging tool:
+
 ```bash
-# pip install swarmauri_storage_file (when published)
+pip install swarmauri_storage_file
+```
+
+```bash
+poetry add swarmauri_storage_file
+```
+
+```bash
+uv pip install swarmauri_storage_file
 ```
 
 ## Usage
 
 ```python
-from swarmauri_storage_file import FileStorageAdapter
+from pathlib import Path
 import io
 
-adapter = FileStorageAdapter(output_dir="/tmp/peagen")
-uri = adapter.upload("example.txt", io.BytesIO(b"hello"))
-print("Stored at", uri)
+from swarmauri_storage_file import FileStorageAdapter
+
+workspace = Path("./artifacts").resolve()
+adapter = FileStorageAdapter(output_dir=workspace)
+
+root_uri = adapter.root_uri
+print("Root URI:", root_uri)
+
+uri = adapter.upload("example.txt", io.BytesIO(b"hello world"))
+print("Stored at:", uri)
+
+downloaded = adapter.download("example.txt").read().decode("utf-8")
+print("Contents:", downloaded)
+
+keys = list(adapter.iter_prefix(""))
+print("Keys:", keys)
 ```
+
+The snippet above resolves a local workspace, uploads an artifact, reads it
+back as text and inspects the stored keys.  URIs returned by ``upload`` reuse
+``root_uri`` (with the relative key appended) so they can be dereferenced by
+tools that understand ``file://`` locations.
+
+### Additional helpers
+
+- ``upload_dir`` recursively walks a source directory and stores each file
+  under an optional destination prefix.
+- ``download_dir`` materializes a stored prefix into a destination directory,
+  recreating any nested structure.
+- ``iter_prefix`` yields keys rooted at ``output_dir`` (including any configured
+  prefix) which is useful for inventory or cleanup tasks.
+- ``from_uri`` rebuilds an adapter from a ``file://`` URI previously emitted by
+  ``root_uri`` or ``upload``.

--- a/pkgs/standards/swarmauri_storage_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_file/pyproject.toml
@@ -49,6 +49,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_storage_file/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_storage_file/tests/example/test_readme_example.py
@@ -1,0 +1,79 @@
+"""Execute the README usage example to ensure it stays accurate."""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+PACKAGE_DIR = Path(__file__).resolve().parents[2]
+if str(PACKAGE_DIR) not in sys.path:  # pragma: no cover - import guard
+    sys.path.insert(0, str(PACKAGE_DIR))
+
+
+def _extract_usage_code(readme: Path) -> str:
+    """Return the first Python code block under the ``Usage`` heading."""
+
+    lines = readme.read_text(encoding="utf-8").splitlines()
+    in_usage = False
+    in_code = False
+    code_lines: list[str] = []
+
+    for line in lines:
+        if not in_usage:
+            if line.strip() == "## Usage":
+                in_usage = True
+            continue
+
+        if not in_code:
+            if line.startswith("## "):
+                break
+            if line.strip().startswith("```python"):
+                in_code = True
+            continue
+
+        if line.strip().startswith("```"):
+            break
+
+        code_lines.append(line)
+
+    if not code_lines:
+        raise AssertionError("Usage example code block not found in README.md")
+
+    return textwrap.dedent("\n".join(code_lines)).strip()
+
+
+@pytest.mark.example
+def test_readme_usage_example(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the README example and assert it produces the expected artifacts."""
+
+    readme = PACKAGE_DIR / "README.md"
+    code = _extract_usage_code(readme)
+
+    monkeypatch.chdir(tmp_path)
+
+    namespace: dict[str, object] = {}
+    exec(code, namespace)
+
+    workspace = namespace["workspace"]
+    assert isinstance(workspace, Path)
+    assert workspace.exists()
+    assert workspace.is_dir()
+    assert workspace.is_relative_to(tmp_path.resolve())
+
+    artifact = workspace / "example.txt"
+    assert artifact.exists()
+    assert artifact.read_text(encoding="utf-8") == "hello world"
+
+    assert namespace["downloaded"] == "hello world"
+    assert namespace["keys"] == ["example.txt"]
+
+    uri = namespace["uri"]
+    root_uri = namespace["root_uri"]
+    assert isinstance(uri, str)
+    assert isinstance(root_uri, str)
+    assert uri.endswith("example.txt")
+    assert root_uri.startswith("file://")


### PR DESCRIPTION
## Summary
- expand the README to document runtime features, modern installation commands, and a usage example that matches the adapter implementation
- add a pytest that extracts and executes the README usage snippet to keep the documentation accurate
- register the `example` pytest marker for the package so the new test runs without warnings

## Testing
- `uv run --directory pkgs/standards/swarmauri_storage_file --package swarmauri_storage_file ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_storage_file --package swarmauri_storage_file pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ca78d9b0d8833188be62f4e49d752b