### PR TITLE
Document secp256k1 signer usage and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_signing_secp256k1/README.md
+++ b/pkgs/standards/swarmauri_signing_secp256k1/README.md
@@ -18,29 +18,111 @@
 
 # Swarmauri Signing Secp256k1
 
-A secp256k1 ECDSA signer implementing the `ISigning` interface for detached
-signatures over raw bytes and canonicalized envelopes.
+An opinionated secp256k1 ECDSA signer that implements the Swarmauri
+`ISigning` interface for detached signatures over raw bytes and
+canonicalized envelopes.
 
-Features:
-- JSON canonicalization (always available)
-- Optional CBOR canonicalization via `cbor2`
-- Detached signatures using `cryptography`'s secp256k1 primitives
+## Features
+
+- **Asynchronous API** – `sign_bytes`, `verify_bytes`, `sign_envelope`, and
+  `verify_envelope` operate with `asyncio` and return canonical Swarmauri
+  signature payloads.
+- **Multiple canonicalizations** – JSON canonicalization is always
+  available, while CBOR canonicalization can be enabled with the optional
+  `cbor2` dependency.
+- **Flexible key loading** – accepts PEM strings/paths, JWK dictionaries, or
+  native `cryptography` key objects via the `KeyRef` protocol.
+- **Deterministic verification requirements** – verification expects one or
+  more secp256k1 public keys provided through `opts["pubkeys"]`.
+- **Signature format control** – DER encoding is returned by default; supply
+  `opts={"format": "RAW"}` when signing or verifying to work with
+  JOSE-style `r || s` concatenated signatures.
 
 ## Installation
 
+The package requires `cryptography` and, optionally, `cbor2` when CBOR
+canonicalization is needed.
+
 ```bash
 pip install swarmauri_signing_secp256k1
+
+# install with CBOR canonicalization support
+pip install "swarmauri_signing_secp256k1[cbor]"
+```
+
+```bash
+poetry add swarmauri_signing_secp256k1
+```
+
+```bash
+uv add swarmauri_signing_secp256k1
+
+# with the optional CBOR extra
+uv add "swarmauri_signing_secp256k1[cbor]"
 ```
 
 ## Usage
 
+### Sign and verify raw bytes
+
+The signer derives a key identifier (`kid`) from the provided private key and
+requires the corresponding public key when verifying signatures.
+
+<!-- example-start -->
 ```python
+import asyncio
+
+from cryptography.hazmat.primitives.asymmetric import ec
+
 from swarmauri_signing_secp256k1 import Secp256k1EnvelopeSigner
 
-signer = Secp256k1EnvelopeSigner()
-# create a KeyRef for a secp256k1 private key; see swarmauri_core for details
+
+async def main() -> bool:
+    signer = Secp256k1EnvelopeSigner()
+
+    private_key = ec.generate_private_key(ec.SECP256K1())
+    key_ref = {"kind": "cryptography_obj", "obj": private_key}
+
+    payload = b"hello from secp256k1"
+    signatures = await signer.sign_bytes(key_ref, payload)
+
+    public_key_ref = {
+        "kind": "cryptography_obj",
+        "obj": private_key.public_key(),
+    }
+    is_valid = await signer.verify_bytes(
+        payload,
+        signatures,
+        opts={"pubkeys": [public_key_ref]},
+    )
+
+    print(f"Signature valid? {is_valid}")
+    assert is_valid
+    return is_valid
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+<!-- example-end -->
+
+### Canonicalized envelopes
+
+To sign envelopes, pass JSON-serializable dictionaries (and optionally
+`canon="cbor"`). Canonicalization reuses the same raw signing logic shown
+above:
+
+```python
+envelope = {"payload": {"msg": "hello"}}
+signatures = await signer.sign_envelope(key_ref, envelope, canon="json")
+is_valid = await signer.verify_envelope(
+    envelope,
+    signatures,
+    opts={"pubkeys": [public_key_ref]},
+)
 ```
 
 ## Entry Point
 
-The signer registers under the `swarmauri.signings` entry point as `Secp256k1EnvelopeSigner`.
+The signer registers under the `swarmauri.signings` entry point as
+`Secp256k1EnvelopeSigner`.

--- a/pkgs/standards/swarmauri_signing_secp256k1/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_secp256k1/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_secp256k1/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_secp256k1/tests/test_readme_example.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_usage_example_executes() -> None:
+    """Execute the README usage example to ensure it stays valid."""
+
+    readme_path = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme_path.read_text(encoding="utf-8")
+
+    match = re.search(
+        r"<!-- example-start -->\s*```python\n(?P<code>.*?)\n```",
+        content,
+        re.DOTALL,
+    )
+    assert match, (
+        "Expected README usage example fenced by <!-- example-start --> markers."
+    )
+
+    example_src = textwrap.dedent(match.group("code"))
+    compiled = compile(example_src, str(readme_path), "exec")
+    exec_globals: dict[str, object] = {"__name__": "__main__"}
+    exec(compiled, exec_globals)


### PR DESCRIPTION
## Summary
- expand the signer README with feature details, pip/poetry/uv installation guidance, and an executable usage example
- register a pytest ``example`` marker and add a README-backed regression test that executes the documented snippet

## Testing
- uv run --directory pkgs/standards/swarmauri_signing_secp256k1 --package swarmauri_signing_secp256k1 pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78d855048331987fb2f714ee050f