### PR TITLE
Align RSA signer README and test quickstart example

### DIFF
--- a/pkgs/standards/swarmauri_signing_rsa/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_rsa/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: README examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_rsa/tests/functional/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_rsa/tests/functional/test_readme_example.py
@@ -1,0 +1,22 @@
+"""Execute the README quickstart example to ensure it remains functional."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_quickstart_executes() -> None:
+    """Load and execute the first Python example from the README."""
+
+    readme_path = pathlib.Path(__file__).resolve().parents[2] / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    match = re.search(r"```python\n(.*?)\n```", readme_text, re.DOTALL)
+    assert match, "README must contain a Python fenced code block"
+
+    code_block = match.group(1)
+    exec(compile(code_block, str(readme_path), "exec"), {})


### PR DESCRIPTION
## Summary
- expand the RSA signer README with capability details, installation commands for pip/Poetry/uv, and a runnable quickstart
- register a pytest marker for documentation examples and add a test that executes the README quickstart snippet

## Testing
- `uv run --directory pkgs/standards/swarmauri_signing_rsa --package swarmauri_signing_rsa ruff format .`
- `uv run --directory pkgs/standards/swarmauri_signing_rsa --package swarmauri_signing_rsa ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_signing_rsa --package swarmauri_signing_rsa pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ca78d663e48331af71079be526cbb5