### PR TITLE
Align JWS README and add example test

### DIFF
--- a/pkgs/standards/swarmauri_signing_jws/README.md
+++ b/pkgs/standards/swarmauri_signing_jws/README.md
@@ -18,37 +18,94 @@
 
 # Swarmauri Signing JWS
 
-Composite JSON Web Signature (JWS) signer and verifier combining multiple
-Swarmauri signing providers.
+Composite JSON Web Signature (JWS) signer and verifier that orchestrates
+multiple Swarmauri signing providers behind a single asynchronous API.
 
-Features:
-- Supports compact and general JWS serialization
-- Routes algorithms to existing HMAC, RSA, ECDSA, Ed25519, and optional
-  secp256k1 signers
-- Optional CBOR canonicalization via `cbor2`
+## Features
+
+- Async helpers for both compact and general JSON JWS serialization
+- Algorithm routing across HMAC (HS256/384/512), RSA (RS*/PS*), ECDSA
+  (ES256/384/512), Ed25519 (EdDSA), and optional secp256k1 (ES256K when the
+  `secp256k1` extra is installed)
+- Works with direct key material, Swarmauri signer objects, or a JWKS resolver
+  while returning the protected header and payload via `JwsResult`
 
 ## Installation
+
+### pip
 
 ```bash
 pip install swarmauri_signing_jws
 ```
 
+### Poetry
+
+```bash
+poetry add swarmauri_signing_jws
+```
+
+### uv
+
+To add the dependency to a `pyproject.toml` managed by `uv`:
+
+```bash
+uv add swarmauri_signing_jws
+```
+
+Or install it into the active environment:
+
+```bash
+uv pip install swarmauri_signing_jws
+```
+
+Optional extras:
+
+- `secp256k1` enables ES256K support through `swarmauri_signing_secp256k1`
+
 ## Usage
 
 ```python
+import asyncio
 from swarmauri_signing_jws import JwsSignerVerifier
 
-verifier = JwsSignerVerifier()
-compact = await verifier.sign_compact(
-    payload={"msg": "hi"},
-    alg="HS256",
-    key={"kind": "raw", "key": "0" * 32},
-)
-result = await verifier.verify_compact(
-    compact,
-    hmac_keys=[{"kind": "raw", "key": "0" * 32}],
-)
+
+async def main() -> None:
+    signer = JwsSignerVerifier()
+    key = {"kind": "raw", "key": "0" * 32}
+
+    compact = await signer.sign_compact(
+        payload={"msg": "hi"},
+        alg="HS256",
+        key=key,
+    )
+
+    result = await signer.verify_compact(
+        compact,
+        hmac_keys=[key],
+    )
+
+    print(result.payload.decode("utf-8"))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
+
+The public methods accept either raw strings or `JWAAlg` enum values for the
+`alg` parameter. Compact verification returns a `JwsResult` dataclass containing
+the parsed header and payload bytes so applications can safely forward or decode
+the authenticated message.
+
+## API highlights
+
+- `sign_compact(...)` / `verify_compact(...)` wrap the standard compact
+  serialization, including optional allowlists and JWKS resolvers.
+- `sign_general_json(...)` / `verify_general_json(...)` operate on the general
+  JSON serialization and support multi-signer verification with `min_signers`
+  thresholds.
+- Each algorithm family accepts dedicated key collections (`hmac_keys`,
+  `rsa_pubkeys`, `ec_pubkeys`, `ed_pubkeys`, `k1_pubkeys`) or a `jwks_resolver`
+  callback for dynamic key retrieval.
 
 ## HMAC key requirements
 

--- a/pkgs/standards/swarmauri_signing_jws/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_jws/pyproject.toml
@@ -48,6 +48,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_jws/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/test_readme_example.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pathlib
+import textwrap
+
+import pytest
+
+
+_README = pathlib.Path(__file__).resolve().parent.parent / "README.md"
+
+
+def _extract_usage_snippet(text: str) -> str:
+    marker = "## Usage"
+    start = text.index(marker)
+    block_start = text.index("```python", start)
+    block_end = text.index("```", block_start + len("```python"))
+    snippet = text[block_start + len("```python") : block_end]
+    return textwrap.dedent(snippet).strip()
+
+
+@pytest.mark.example
+def test_readme_usage_example(capsys: pytest.CaptureFixture[str]) -> None:
+    snippet = _extract_usage_snippet(_README.read_text(encoding="utf-8"))
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(compile(snippet, str(_README), "exec"), namespace)
+    captured = capsys.readouterr()
+    assert captured.out.strip().endswith('{"msg":"hi"}')


### PR DESCRIPTION
## Summary
- refresh the JwsSignerVerifier README to describe the async API, add Poetry/uv installation guidance, and clarify usage
- add a pytest that executes the README usage example and register the example marker

## Testing
- uv run --directory pkgs/standards/swarmauri_signing_jws --package swarmauri_signing_jws ruff format .
- uv run --directory pkgs/standards/swarmauri_signing_jws --package swarmauri_signing_jws ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signing_jws --package swarmauri_signing_jws pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78d5af0083318f0f55c7cf29f282