### PR TITLE
Align swarmauri_signing_pgp documentation with behavior

### DIFF
--- a/pkgs/standards/swarmauri_signing_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_pgp/pyproject.toml
@@ -42,6 +42,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation example tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_pgp/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_pgp/tests/example/test_readme_example.py
@@ -1,0 +1,29 @@
+"""Execute the README usage example to ensure it stays accurate."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+
+
+def _readme_usage_code() -> str:
+    text = README_PATH.read_text(encoding="utf-8")
+    match = re.findall(r"```python\n(.*?)```", text, flags=re.DOTALL)
+    if not match:
+        raise AssertionError("README example missing python code block.")
+    return match[0]
+
+
+@pytest.mark.example
+def test_readme_usage_example(capsys: pytest.CaptureFixture[str]) -> None:
+    capsys.readouterr()
+    code = _readme_usage_code()
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(code, namespace)
+    captured = capsys.readouterr()
+    assert "Verified: True" in captured.out


### PR DESCRIPTION
## Summary
- expand the Swarmauri Signing PGP README with accurate usage guidance, including Poetry/uv install commands and canonicalization details
- add a README-backed example test that executes the documented usage and register the pytest ``example`` marker for the package

## Testing
- uv run --directory pkgs/standards/swarmauri_signing_pgp --package swarmauri_signing_pgp ruff format .
- uv run --directory pkgs/standards/swarmauri_signing_pgp --package swarmauri_signing_pgp ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signing_pgp --package swarmauri_signing_pgp pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78d4b10883319af1833319148cde