### PR TITLE
Document HMAC signer keys and README example coverage

### DIFF
--- a/pkgs/standards/swarmauri_signing_hmac/README.md
+++ b/pkgs/standards/swarmauri_signing_hmac/README.md
@@ -25,6 +25,7 @@ signatures over raw bytes and canonicalized envelopes.
 - JSON canonicalization (always available)
 - Optional CBOR canonicalization via `cbor2`
 - Detached signatures using standard library `hmac`
+- Supports raw, hex, environment, and HKDF-derived `KeyRef` secrets.
 
 ## Security Notes
 
@@ -32,11 +33,28 @@ signatures over raw bytes and canonicalized envelopes.
 - Keys must be at least 32 bytes (256 bits).
 - Tags default to the hash digest size and may be truncated via
   `opts["tag_size"]` but not below 16 bytes (128 bits).
+- Secrets shorter than 32 bytes are rejected even when using a longer digest.
 
 ## Installation
 
+Install the package with your preferred Python packaging tool:
+
 ```bash
 pip install swarmauri_signing_hmac
+```
+
+```bash
+poetry add swarmauri_signing_hmac
+```
+
+```bash
+uv pip install swarmauri_signing_hmac
+```
+
+Install `cbor2` to enable CBOR canonicalization:
+
+```bash
+pip install cbor2
 ```
 
 ## Usage
@@ -70,6 +88,20 @@ asyncio.run(main())
 ```
 
 Verification requires providing one or more keys via `opts["keys"]`.
+
+### Key references
+
+`HmacEnvelopeSigner` accepts multiple `KeyRef` forms:
+
+- `{"kind": "raw", "key": <bytes-or-str>}` – direct secret material.
+- `{"kind": "hex", "key": <hex str>}` – hex encoded secret.
+- `{"kind": "env", "name": <ENV_NAME>}` – loads the secret from an environment
+  variable.
+- `{"kind": "derived", "key": <bytes-or-str>, "hkdf": {"salt": ..., "info": ...}}`
+  – derives the signing secret with HKDF.
+
+Provide an optional `"kid"` to control the key identifier or specify
+`"alg"` when verifying to override the default `HS256` digest for a key entry.
 
 ## Entry Point
 

--- a/pkgs/standards/swarmauri_signing_hmac/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_hmac/pyproject.toml
@@ -38,6 +38,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_hmac/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_hmac/tests/example/test_readme_example.py
@@ -1,0 +1,29 @@
+"""Exercises the README usage example to prevent regressions."""
+
+import pytest
+
+from swarmauri_signing_hmac import HmacEnvelopeSigner
+from swarmauri_core.crypto.types import JWAAlg
+
+
+@pytest.mark.asyncio
+@pytest.mark.example
+async def test_readme_usage_example() -> None:
+    signer = HmacEnvelopeSigner()
+
+    key = {"kind": "raw", "key": "a" * 32}
+    payload = b"hello"
+
+    sigs = await signer.sign_bytes(
+        key, payload, alg=JWAAlg.HS256, opts={"tag_size": 16}
+    )
+    assert await signer.verify_bytes(payload, sigs, opts={"keys": [key]})
+
+    env = {"msg": "hello"}
+    sigs_env = await signer.sign_envelope(
+        key, env, alg=JWAAlg.HS256, canon="json", opts={"tag_size": 16}
+    )
+
+    assert await signer.verify_envelope(
+        env, sigs_env, canon="json", opts={"keys": [key]}
+    )


### PR DESCRIPTION
## Summary
- align the README with the signer implementation by documenting supported KeyRef forms, installation options, and optional CBOR support
- register a dedicated pytest marker for README-backed examples and add an async test that runs the documented usage example

## Testing
- `uv run --directory pkgs/standards/swarmauri_signing_hmac --package swarmauri_signing_hmac ruff format .`
- `uv run --directory pkgs/standards/swarmauri_signing_hmac --package swarmauri_signing_hmac ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_signing_hmac --package swarmauri_signing_hmac pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ca78c438b48331beee9aedca864eb1