### PR TITLE
Document Ed25519 signer usage and test README example

### DIFF
--- a/pkgs/standards/swarmauri_signing_ed25519/README.md
+++ b/pkgs/standards/swarmauri_signing_ed25519/README.md
@@ -18,29 +18,105 @@
 
 # Swarmauri Signing Ed25519
 
-An Ed25519-based signer implementing the `ISigning` interface for detached
-signatures over raw bytes and canonicalized envelopes.
+`swarmauri_signing_ed25519` provides an Ed25519 implementation of the
+`ISigning` interface for creating detached signatures over byte payloads and
+canonicalized envelopes.
 
-Features:
-- JSON canonicalization (always available)
-- Optional CBOR canonicalization via `cbor2`
-- Detached signatures using `cryptography`'s Ed25519 primitives
+## Features
+
+- Deterministic JSON canonicalization is always available, ensuring stable
+  digests for dictionary-based envelopes.
+- Optional CBOR canonicalization can be enabled with the `[cbor]` extra to
+  install the `cbor2` dependency.
+- Detached signatures are produced with `cryptography`'s Ed25519 primitives and
+  returned as sequences so multi-signature workflows remain possible.
+- Verification accepts multiple public keys via `opts["pubkeys"]` and honours
+  `require={"min_signers": N}` for quorum checks.
+- Ed25519 private keys can be supplied either as cryptography objects or raw
+  seed bytes using the `KeyRef` helper structure from `swarmauri_core`.
 
 ## Installation
+
+### pip
 
 ```bash
 pip install swarmauri_signing_ed25519
 ```
 
+### Poetry
+
+```bash
+poetry add swarmauri_signing_ed25519
+```
+
+### uv
+
+```bash
+uv add swarmauri_signing_ed25519
+```
+
+Install with the `[cbor]` extra when CBOR canonicalization is required:
+
+```bash
+pip install "swarmauri_signing_ed25519[cbor]"
+poetry add swarmauri_signing_ed25519[cbor]
+uv add swarmauri_signing_ed25519[cbor]
+```
+
 ## Usage
 
+The package exposes a single entry point, `Ed25519EnvelopeSigner`, implementing
+`ISigning`. The signer reports JSON (and optionally CBOR) support via
+`supports()`, canonicalizes envelopes through `canonicalize_envelope`, and
+produces detached signatures using `sign_bytes`/`sign_envelope`. Verification
+expects the relevant public keys to be supplied using `opts["pubkeys"]`.
+
+### Key references
+
+`Ed25519EnvelopeSigner` accepts Ed25519 private keys using `KeyRef` values. The
+two supported forms are:
+
+- `{"kind": "cryptography_obj", "obj": Ed25519PrivateKey}` for in-memory
+  cryptography objects.
+- `{"kind": "raw_ed25519_sk", "bytes": seed}` where `seed` is the 32-byte
+  private key seed (or the 64-byte expanded secret key).
+
+## Example
+
+The example below signs a JSON envelope and verifies the detached signature with
+the generated public key.
+
+<!-- example-start -->
 ```python
+import asyncio
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
 from swarmauri_signing_ed25519 import Ed25519EnvelopeSigner
 
-signer = Ed25519EnvelopeSigner()
-# create a KeyRef for an Ed25519 private key; see swarmauri_core for details
+
+async def main() -> bool:
+    signer = Ed25519EnvelopeSigner()
+    private_key = Ed25519PrivateKey.generate()
+    key_ref = {"kind": "cryptography_obj", "obj": private_key}
+
+    envelope = {"subject": "alice", "scope": ["inbox:read"]}
+    signatures = await signer.sign_envelope(key_ref, envelope)
+
+    public_key = private_key.public_key()
+    verified = await signer.verify_envelope(
+        envelope,
+        signatures,
+        opts={"pubkeys": [public_key]},
+    )
+    return verified
+
+
+verified = asyncio.run(main())
+print(f"Signature verified? {verified}")
 ```
+<!-- example-end -->
 
 ## Entry Point
 
-The signer registers under the `swarmauri.signings` entry point as `Ed25519EnvelopeSigner`.
+The signer registers under the `swarmauri.signings` entry point as
+`Ed25519EnvelopeSigner`.

--- a/pkgs/standards/swarmauri_signing_ed25519/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ed25519/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_ed25519/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_ed25519/tests/test_readme_example.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import Any, Dict
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_example_executes() -> None:
+    readme = pathlib.Path(__file__).resolve().parent.parent / "README.md"
+    text = readme.read_text(encoding="utf-8")
+    match = re.search(
+        r"<!-- example-start -->\s*```python\n(?P<code>.*?)```",
+        text,
+        flags=re.DOTALL,
+    )
+    assert match, "Example code block not found in README"
+
+    namespace: Dict[str, Any] = {"__name__": "__main__"}
+    code = match.group("code")
+    exec(compile(code, str(readme), "exec"), namespace)
+    assert namespace.get("verified") is True, (
+        "README example should set `verified` to True"
+    )


### PR DESCRIPTION
## Summary
- expand the Ed25519 signer README with accurate feature notes, installation guidance, and a runnable example
- describe supported key reference shapes and optional CBOR support so the docs match the implementation
- add a pytest that executes the README example and register the corresponding pytest mark

## Testing
- uv run --directory pkgs/standards/swarmauri_signing_ed25519 --package swarmauri_signing_ed25519 pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78c32ce083319a72e7fb1d2727a5