### PR TITLE
Document ECDSA signer usage and test README example

### DIFF
--- a/pkgs/standards/swarmauri_signing_ecdsa/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ecdsa/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_ecdsa/tests/functional/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_ecdsa/tests/functional/test_readme_example.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pathlib
+import re
+import textwrap
+
+import pytest
+
+
+def _readme_path() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[2] / "README.md"
+
+
+def _extract_readme_example() -> str:
+    readme_text = _readme_path().read_text(encoding="utf-8")
+    match = re.search(r"```python\n(?P<code>.*?)\n```", readme_text, re.DOTALL)
+    if not match:  # pragma: no cover - defensive guard
+        raise AssertionError("README is missing the expected python example block.")
+    return textwrap.dedent(match.group("code")).strip()
+
+
+@pytest.mark.example
+def test_readme_example_executes(capsys):
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(compile(_extract_readme_example(), str(_readme_path()), "exec"), namespace)
+    captured = capsys.readouterr()
+    assert "Signature valid? True" in captured.out


### PR DESCRIPTION
## Summary
- refresh the ECDSA signer README with feature notes, pip/poetry/uv install guidance, and an async usage example that matches the implementation
- register an `example` pytest mark and add a README-backed test that executes the documented example

## Testing
- uv run --directory pkgs/standards/swarmauri_signing_ecdsa --package swarmauri_signing_ecdsa ruff format .
- uv run --directory pkgs/standards/swarmauri_signing_ecdsa --package swarmauri_signing_ecdsa ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signing_ecdsa --package swarmauri_signing_ecdsa pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78c168b083318267752e510e5f3e