### PR TITLE
Align DPoP README with implementation and add example test

### DIFF
--- a/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: README-backed example tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_dpop/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_signing_dpop/tests/test_readme_example.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_example_executes() -> None:
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text(encoding="utf-8")
+    match = re.search(r"```python\n(.*?)\n```", content, re.DOTALL)
+    assert match is not None, "No python example found in README"
+
+    code = textwrap.dedent(match.group(1))
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(compile(code, str(readme), "exec"), namespace)


### PR DESCRIPTION
## Summary
- align the DPoP README with the implementation, expanding feature notes and adding pip/uv/Poetry installation guidance
- refresh the usage example to generate a working Ed25519 key and document signature, key, and option semantics
- execute the README example in a new pytest marked `example` and register the marker in the package config

## Testing
- `uv run --directory pkgs/standards --package swarmauri_signing_dpop ruff format .`
- `uv run --directory pkgs/standards --package swarmauri_signing_dpop ruff check . --fix`
- `uv run --directory pkgs/standards --package swarmauri_signing_dpop pytest swarmauri_signing_dpop`


------
https://chatgpt.com/codex/tasks/task_b_68ca78c068c88331916bdb4421d6a251