### PR TITLE
Update J2PromptTemplate README and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
@@ -1,58 +1,88 @@
 ![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
-    <a href="https://pypi.org/project/swarmauri_tool_j2prompttemplate/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri_tool_j2prompttemplate" alt="PyPI - Downloads"/></a>
+    <a href="https://pypi.org/project/swarmauri_prompt_j2prompttemplate/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_prompt_j2prompttemplate" alt="PyPI - Downloads"/></a>
     <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_prompt_j2prompttemplate/">
         <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_prompt_j2prompttemplate.svg"/></a>
-    <a href="https://pypi.org/project/swarmauri_tool_j2prompttemplate/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tool_j2prompttemplate" alt="PyPI - Python Version"/></a>
-    <a href="https://pypi.org/project/swarmauri_tool_j2prompttemplate/">
-        <img src="https://img.shields.io/pypi/l/swarmauri_tool_j2prompttemplate" alt="PyPI - License"/></a>
-    <a href="https://pypi.org/project/swarmauri_tool_j2prompttemplate/">
-        <img src="https://img.shields.io/pypi/v/swarmauri_tool_j2prompttemplate?label=swarmauri_tool_j2prompttemplate&color=green" alt="PyPI - swarmauri_tool_j2prompttemplate"/></a>
+    <a href="https://pypi.org/project/swarmauri_prompt_j2prompttemplate/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_prompt_j2prompttemplate" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_prompt_j2prompttemplate/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_prompt_j2prompttemplate" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_prompt_j2prompttemplate/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_prompt_j2prompttemplate?label=swarmauri_prompt_j2prompttemplate&color=green" alt="PyPI - swarmauri_prompt_j2prompttemplate"/></a>
 </p>
 
 ---
 
-# Swarmauri Tool J2PromptTemplate
+# Swarmauri Prompt J2PromptTemplate
 
-A Swarmauri package that provides tools for generating prompts using Jinja2 templates. Includes support for dynamic template rendering and variable substitution.
+`J2PromptTemplate` is the Swarmauri Jinja2 prompt template implementation. It
+accepts literal template strings or template files, renders them with the
+variables you provide, and registers itself as the `J2PromptTemplate`
+`swarmauri.prompts` entry point.
+
+## Highlights
+
+- Load template content from inline strings or filesystem paths.
+- Configure one or more search directories via `templates_dir` for reusable
+  Jinja2 templates with fallback lookup.
+- Ship with helpful filters (`split`, `make_singular`, `make_plural`) for prompt
+  engineering tasks.
+- Call the instance directly (`template({...})`) or use `generate_prompt()` to
+  render with the stored variables.
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
-pip install swarmauri_tool_j2prompttemplate
+# pip
+pip install swarmauri_prompt_j2prompttemplate
+
+# Poetry
+poetry add swarmauri_prompt_j2prompttemplate
+
+# uv
+uv add swarmauri_prompt_j2prompttemplate
 ```
 
 ## Usage
 
-### Basic Template Rendering
+### Render a template string
+
 ```python
-from swarmauri_tool_j2prompttemplate.J2PromptTemplate import J2PromptTemplate
+from swarmauri_prompt_j2prompttemplate import J2PromptTemplate
 
-# Create a template instance
 template = J2PromptTemplate(template="Hello, {{ name }}!")
-
-# Generate a prompt
-result = template(variables={"name": "World"})
-print(result)  # Output: Hello, World!
+result = template({"name": "World"})
+print(result)  # Hello, World!
 ```
 
-### Template Rendering from File
+### Load templates from disk (with filters and search paths)
+
 ```python
-from swarmauri_tool_j2prompttemplate.J2PromptTemplate import J2PromptTemplate
 from pathlib import Path
 
-# Create a template instance with a file path
-template_path = Path("path/to/template.j2")
-template = J2PromptTemplate(template=template_path)
+from swarmauri_prompt_j2prompttemplate import J2PromptTemplate
 
-# Generate a prompt
-result = template(variables={"name": "World"})
-print(result)
+templates_dir = Path("templates")
+templates_dir.mkdir(parents=True, exist_ok=True)
+
+template_path = templates_dir / "greeting.j2"
+template_path.write_text("Hello, {{ animal|make_plural }}!", encoding="utf-8")
+
+prompt = J2PromptTemplate(templates_dir=str(templates_dir))
+prompt.set_template(template_path)
+
+print(prompt({"animal": "fox"}))  # Hello, foxes!
 ```
+
+`set_template()` loads the file with the configured environment. The template
+file is located relative to the provided `templates_dir`. If the loader cannot
+find it immediately, the class searches recursively before falling back to the
+template's own directory.
 
 ## Want to help?
 
-If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) that will help you get started.

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/pyproject.toml
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/pyproject.toml
@@ -30,6 +30,7 @@ norecursedirs = ["combined", "scripts"]
 markers = [
     "test: standard test",
     "unit: Unit tests",
+    "example: Documentation examples",
     "i9n: Integration tests",
     "r8n: Regression tests",
     "timeout: mark test to timeout after X seconds",

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/test_readme_examples.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/test_readme_examples.py
@@ -1,0 +1,57 @@
+"""Execute the README examples to ensure they stay accurate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def _python_code_blocks(readme: str) -> list[str]:
+    blocks: list[str] = []
+    in_block = False
+    current: list[str] = []
+
+    for line in readme.splitlines():
+        if line.startswith("```python"):
+            in_block = True
+            current = []
+            continue
+        if in_block and line.startswith("```"):
+            blocks.append("\n".join(current))
+            in_block = False
+            current = []
+            continue
+        if in_block:
+            current.append(line)
+
+    return blocks
+
+
+@pytest.mark.example
+def test_readme_examples(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    examples = _python_code_blocks(readme_text)
+
+    assert len(examples) >= 2, (
+        "Expected at least two python code examples in the README"
+    )
+
+    # Execute the inline template example.
+    inline_namespace: dict[str, object] = {}
+    exec(examples[0], inline_namespace)
+    assert inline_namespace["result"] == "Hello, World!"
+
+    # Run the filesystem-backed example inside an isolated working directory.
+    fs_namespace: dict[str, object] = {}
+    example_dir = tmp_path / "readme"
+    example_dir.mkdir()
+    monkeypatch.chdir(example_dir)
+    exec(examples[1], fs_namespace)
+
+    prompt = fs_namespace["prompt"]
+    assert callable(prompt)
+    assert prompt({"animal": "fox"}) == "Hello, foxes!"


### PR DESCRIPTION
## Summary
- align the README with the actual swarmauri_prompt_j2prompttemplate package name and behavior
- document pip, Poetry, and uv installation steps plus updated usage examples
- add a pytest marked example that executes the README code blocks and register the marker

## Testing
- uv run --directory . --package swarmauri_prompt_j2prompttemplate pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78627558833187f61e4ec8113602