### PR TITLE
docs: document HttpSig middleware example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_httpsig/README.md
+++ b/pkgs/standards/swarmauri_middleware_httpsig/README.md
@@ -22,14 +22,104 @@
 
 # Swarmauri Middleware HttpSig
 
-Middleware for verifying HTTP signatures in Swarmauri applications.
+`HttpSigMiddleware` verifies a base64-encoded HMAC-SHA256 signature on every
+incoming request body. The middleware compares the provided signature (default
+header `X-Signature`) with one generated from the request payload using a
+shared secret. Missing or incorrect signatures are rejected with `401`.
+
+## Features
+
+- Validates request payloads with an HMAC-SHA256 digest
+- Uses constant-time comparisons to mitigate timing attacks
+- Configurable signature header via the `header_name` argument
+- Logs and rejects requests that do not supply a valid signature
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_middleware_httpsig
+
+# Poetry
+poetry add swarmauri_middleware_httpsig
+
+# uv
+uv add swarmauri_middleware_httpsig
+```
+
+## Example
+
+The snippet below wires the middleware into FastAPI via the `@app.middleware`
+decorator, signs a request body, and demonstrates the `401` response that
+occurs when a tampered signature is supplied. The middleware raises
+`HTTPException`, so the example also converts those errors to JSON responses.
+
+```python
+import base64
+import hashlib
+import hmac
+import json
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+from fastapi.responses import JSONResponse
+
+from swarmauri_middleware_httpsig import HttpSigMiddleware
+
+
+app = FastAPI()
+http_sig = HttpSigMiddleware(secret_key="supersecret")
+
+
+@app.middleware("http")
+async def verify_signature(request: Request, call_next):
+    try:
+        return await http_sig.dispatch(request, call_next)
+    except HTTPException as exc:
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+
+@app.post("/echo")
+async def echo(payload: dict) -> dict:
+    return payload
+
+
+def create_signature(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).digest()
+    return base64.b64encode(digest).decode()
+
+
+if __name__ == "__main__":
+    client = TestClient(app)
+
+    body = json.dumps({"message": "hello"}).encode()
+    signature = create_signature("supersecret", body)
+
+    ok = client.post(
+        "/echo",
+        data=body,
+        headers={
+            "X-Signature": signature,
+            "Content-Type": "application/json",
+        },
+    )
+    assert ok.status_code == 200
+    print("Verified response:", ok.json())
+
+    bad = client.post(
+        "/echo",
+        data=body,
+        headers={
+            "X-Signature": "tampered",
+            "Content-Type": "application/json",
+        },
+    )
+    assert bad.status_code == 401
+    print("Unauthorized status:", bad.status_code)
 ```
 
 ## Want to help?
 
-If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_httpsig/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_httpsig/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: README-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_httpsig/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_httpsig/tests/test_readme_example.py
@@ -1,0 +1,25 @@
+"""Execute the README example to ensure it stays runnable."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+
+README_PATH = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+EXAMPLE_PATTERN = re.compile(r"## Example.*?```python\n(?P<code>.*?)\n```", re.S)
+
+
+@pytest.mark.example
+def test_readme_example_executes():
+    """Run the README example and assert it remains valid."""
+
+    content = README_PATH.read_text(encoding="utf-8")
+    match = EXAMPLE_PATTERN.search(content)
+    assert match, "Unable to locate example code block in README.md"
+
+    code = match.group("code")
+    exec_globals = {"__name__": "__main__"}
+    exec(compile(code, str(README_PATH), "exec"), exec_globals)  # noqa: S102


### PR DESCRIPTION
## Summary
- refresh the HTTP signature middleware README with feature notes, pip/Poetry/uv installation commands, and a runnable FastAPI example that mirrors the middleware’s behaviour
- register a pytest ``example`` marker and add a README-backed test that executes the documented sample to keep it working

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_httpsig --package swarmauri_middleware_httpsig ruff format .
- uv run --directory pkgs/standards/swarmauri_middleware_httpsig --package swarmauri_middleware_httpsig ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_middleware_httpsig --package swarmauri_middleware_httpsig pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca7814c7bc8331938dd08befd95787