### PR TITLE
docs: sync jwks verifier README with runtime behavior

### DIFF
--- a/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
@@ -18,28 +18,97 @@
 
 # Swarmauri Middleware JWKS Verifier
 
-A middleware component providing JWT verification using a cached JWKS with TTL and LRU eviction.
+A middleware component providing JWT verification using a cached JWKS with TTL
+and LRU eviction.
 
-Features:
-- Supports RSA, EC, Ed25519, and HMAC keys from JWKS (RFC 7517)
-- Thread-safe cache with TTL refresh and LRU eviction
-- Optional issuer and algorithm whitelisting
+## Features
+
+- Parses RSA, EC, Ed25519, and HMAC keys from JWKS documents (RFC 7517).
+- Thread-safe cache with configurable TTL refresh and LRU eviction limits.
+- Optional constructor guards for allowed algorithms and issuer values.
+- Manual cache controls for forced refreshes, invalidation, and overrides.
 
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_middleware_jwksverifier
 ```
 
-## Usage
+```bash
+poetry add swarmauri_middleware_jwksverifier
+```
+
+```bash
+uv pip install swarmauri_middleware_jwksverifier
+```
+
+## Quickstart
+
+`CachedJWKSVerifier` expects a callable that returns a JWKS document. The fetch
+callback is invoked whenever the cache expires (default `ttl_s=300` seconds) or
+when a forced refresh is requested.
+
+The verifier exposes a `verify` helper that performs signature validation and
+standard PyJWT checks. Pass the algorithms you are willing to accept by
+supplying the `algorithms_whitelist` parameter on every verification call. If
+you do not provide an explicit `issuer`, the first value from
+`allowed_issuers` (if configured during construction) is used.
 
 ```python
+import base64
+
+import jwt
+
 from swarmauri_middleware_jwksverifier import CachedJWKSVerifier
 
-verifier = CachedJWKSVerifier(fetch=my_fetch_jwks)
-claims = verifier.verify(token, algorithms_whitelist=["RS256"], audience="me")
+SECRET = b"super-secret-signing-key"
+
+
+def fetch_jwks() -> dict[str, object]:
+    return {
+        "keys": [
+            {
+                "kty": "oct",
+                "kid": "demo",
+                "k": base64.urlsafe_b64encode(SECRET).rstrip(b"=").decode("ascii"),
+                "alg": "HS256",
+            }
+        ]
+    }
+
+
+verifier = CachedJWKSVerifier(fetch=fetch_jwks, ttl_s=60)
+
+token = jwt.encode(
+    {"sub": "user-123", "aud": "example-service"},
+    SECRET,
+    algorithm="HS256",
+    headers={"kid": "demo"},
+)
+
+claims = verifier.verify(
+    token,
+    algorithms_whitelist=["HS256"],
+    audience="example-service",
+)
+
+print(claims["sub"])
 ```
+
+### Cache management helpers
+
+- `refresh(force: bool = False)` — trigger a JWKS refresh immediately when
+  `force` is true or the cache has expired.
+- `invalidate(kid: Optional[str] = None)` — drop either a specific key or the
+  entire cache, including overrides.
+- `inject_override_key(kid, key_obj)` / `inject_override_jwk(kid, jwk)` — add
+  temporary key material that bypasses JWKS fetching when resolving by `kid`.
+- `key_resolver()` — obtain a callable suitable for advanced PyJWT usage when
+  integrating with other verification flows.
 
 ## Entry Point
 
-The middleware registers under the `swarmauri.middlewares` entry point as `CachedJWKSVerifier`.
+The middleware registers under the `swarmauri.middlewares` entry point as
+`CachedJWKSVerifier`.

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/pyproject.toml
@@ -44,6 +44,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/tests/test_readme_example.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+import textwrap
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_example_executes() -> None:
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    contents = readme.read_text(encoding="utf-8")
+    try:
+        _, remainder = contents.split("```python", 1)
+    except ValueError as exc:  # pragma: no cover - protects against README drift
+        raise AssertionError("README is missing a Python example block") from exc
+    code_block, _ = remainder.split("```", 1)
+    code = textwrap.dedent(code_block).strip()
+
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(code, namespace)  # noqa: S102 - intentional execution of documentation example
+
+    assert namespace.get("claims")
+    assert namespace["claims"].get("sub") == "user-123"


### PR DESCRIPTION
## Summary
- expand the JWKS verifier README with accurate feature descriptions, install commands for pip/poetry/uv, and a runnable quickstart example
- document cache management helpers so the README reflects the middleware API surface
- add a README-backed pytest that executes the documented example and register a pytest ``example`` mark for the package

## Testing
- uv run --directory pkgs/standards --package swarmauri_middleware_jwksverifier ruff format .
- uv run --directory pkgs/standards --package swarmauri_middleware_jwksverifier ruff check . --fix
- uv run --directory pkgs/standards --package swarmauri_middleware_jwksverifier pytest swarmauri_middleware_jwksverifier/tests

------
https://chatgpt.com/codex/tasks/task_b_68ca781189b48331afe644e95208211b