### PR TITLE
Improve swarmauri_signing_ca README example coverage

### DIFF
--- a/pkgs/standards/swarmauri_signing_ca/README.md
+++ b/pkgs/standards/swarmauri_signing_ca/README.md
@@ -18,30 +18,113 @@
 
 # Swarmauri Signing CA
 
-A certificate-authority-capable signer implementing the `ISigning` interface for detached
-signatures over raw bytes and canonicalized envelopes. Provides helpers for creating CSRs,
-signing certificates, and verifying simple chains.
+`swarmauri_signing_ca` exposes a certificate-authority-capable implementation of
+`ISigning` that focuses on detached signatures over raw bytes and canonicalized
+Swarmauri envelopes. The signer understands common public key algorithms and ships
+with utilities for issuing and validating X.509 material.
 
-Features:
-- JSON canonicalization (built-in)
-- Optional CBOR canonicalization via `cbor2`
-- Supports Ed25519, ECDSA (P-256 and others), and RSA-PSS
+## Highlights
+
+- Deterministic JSON canonicalization for envelopes (JSON is the supported canon).
+- Detached signature support for Ed25519, ECDSA (P-256 and compatible curves), and RSA-PSS/RS256.
+- Accepts PEM-encoded private keys or pre-instantiated cryptography objects via `KeyRef`.
+- X.509 helpers for issuing self-signed certificates, signing CSRs, and verifying simple chains.
+- Advertises the `multi`, `detached_only`, and `x509` features under the `swarmauri.signings` entry point as `CASigner`.
 
 ## Installation
 
+Choose the tool that fits your workflow:
+
 ```bash
+# pip
 pip install swarmauri_signing_ca
+
+# Poetry
+poetry add swarmauri_signing_ca
+
+# uv
+uv add swarmauri_signing_ca
 ```
 
-## Usage
+## Quickstart
+
+The example below generates an Ed25519 key, signs a message, and verifies the
+signature using the same public key. It mirrors what `CASigner` performs in
+production environments.
 
 ```python
+import asyncio
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
 from swarmauri_signing_ca import CASigner
 
-signer = CASigner()
-# create a KeyRef for a private key; see swarmauri_core for details
+
+async def main() -> None:
+    signer = CASigner()
+
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    key_ref = KeyRef(
+        kid="demo-ed25519",
+        version=1,
+        type=KeyType.ED25519,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+    )
+
+    message = b"trust but verify"
+    signatures = await signer.sign_bytes(key_ref, message)
+    signature = signatures[0]
+
+    verified = await signer.verify_bytes(
+        message,
+        signatures,
+        opts={"pubkeys": [private_key.public_key()]},
+    )
+
+    print("Signature algorithm:", signature["alg"])
+    print("Key fingerprint:", key_ref.fingerprint)
+    print("Signature valid:", verified)
+
+    assert verified is True
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
+
+### Notes on verification
+
+`CASigner.verify_bytes` expects the caller to provide one or more verification
+keys via `opts={"pubkeys": [...]}`. Entries may be `cryptography` public-key
+objects or PEM-encoded bytes. The signer reports success as soon as the required
+number of signatures validates against the supplied key material.
+
+### X.509 utilities
+
+Beyond detached signatures, `CASigner` assists with certificate authority tasks:
+
+- `issue_self_signed` – build a CA or leaf certificate directly from a
+  `KeyRef` and subject mapping.
+- `create_csr` – generate a certificate signing request complete with SAN and
+  key-usage extensions.
+- `sign_csr` – issue certificates from CSRs using an existing CA key and
+  certificate chain.
+- `verify_chain` – validate a leaf against an intermediate chain and optional
+  trust anchors with basic time and CA checks.
+
+These helpers rely on the same key-loading logic demonstrated in the quickstart,
+so PEM-encoded keys or `KeyRef.tags["crypto_obj"]` objects both work seamlessly.
 
 ## Entry Point
 
-The signer registers under the `swarmauri.signings` entry point as `CASigner`.
+The signer registers under the `swarmauri.signings` entry point as `CASigner` and
+can be resolved through the Swarmauri plugin manager alongside other signing
+implementations.

--- a/pkgs/standards/swarmauri_signing_ca/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ca/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: README-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_signing_ca/tests/example/test_readme_quickstart.py
+++ b/pkgs/standards/swarmauri_signing_ca/tests/example/test_readme_quickstart.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+
+
+def _extract_quickstart_code() -> str:
+    text = README_PATH.read_text(encoding="utf-8")
+    match = re.search(r"```python\n(.*?)\n```", text, re.DOTALL)
+    if not match:  # pragma: no cover - defensive, ensured by assert below
+        raise AssertionError("README quickstart example not found")
+    return match.group(1)
+
+
+@pytest.mark.example
+def test_readme_quickstart_executes() -> None:
+    code = _extract_quickstart_code()
+    namespace: dict[str, object] = {"__name__": "__README__"}
+    exec(code, namespace)
+
+    main = namespace.get("main")
+    assert callable(main), "README quickstart must define main()"
+
+    asyncio.run(main())  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- refresh the swarmauri_signing_ca README with accurate highlights, multi-tool installation steps, and a runnable quickstart example
- register the new example marker in pytest configuration and add a README-backed regression test that executes the documented quickstart

## Testing
- uv run --directory pkgs/standards/swarmauri_signing_ca --package swarmauri_signing_ca ruff format .
- uv run --directory pkgs/standards/swarmauri_signing_ca --package swarmauri_signing_ca ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signing_ca --package swarmauri_signing_ca pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca78be73a8833184e740d2177558b9