### PR TITLE
docs: refresh pgp mre README

### DIFF
--- a/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
@@ -17,22 +17,62 @@
 
 ## Swarmauri MRE Crypto PGP
 
-OpenPGP-based multi-recipient encryption providers implementing the
-`IMreCrypto` contract. This package exposes three providers:
+OpenPGP-based multi-recipient encryption providers that implement the
+`IMreCrypto` contract. The package includes three concrete providers, all of
+which rely on [PGPy](https://pgpy.readthedocs.io/) for public-key encryption.
+Providers that wrap a shared content-encryption key (CEK) additionally require
+[`cryptography`](https://cryptography.io/en/latest/).
 
-* **PGPSealMreCrypto** – per-recipient sealed payloads
-  (`sealed_per_recipient` mode).
-* **PGPSealedCekMreCrypto** – shared AEAD payload with per-recipient sealed
-  CEK (`sealed_cek+aead` mode).
-* **PGPMreCrypto** – composite provider supporting both the
-  `enc_once+per_recipient_header` and `sealed_per_recipient` modes.
+### Highlights
 
-All providers use OpenPGP public key encryption via PGPy.
+- **PGPSealMreCrypto** – Implements the `sealed_per_recipient` mode. Each
+  recipient receives a sealed copy of the plaintext. Associated data (AAD) is
+  not supported and re-wrapping new recipients requires the original plaintext
+  via `opts["plaintext"]`.
+- **PGPSealedCekMreCrypto** – Implements the `sealed_cek+aead` mode with an
+  AES-256-GCM payload. The CEK is sealed per recipient and can be re-used to
+  add or rotate recipients without decrypting the payload when
+  `opts["cek"]` or `opts["opener_identities"]` are supplied.
+- **PGPMreCrypto** – Composite provider supporting both
+  `enc_once+per_recipient_header` (AES-256-GCM payload with OpenPGP headers)
+  and `sealed_per_recipient`. Re-wrapping shared-payload envelopes requires the
+  CEK via `opts["cek"]` or a managing private key supplied through
+  `opts["manage_key"]`.
+
+All providers fingerprint OpenPGP keys to derive recipient identifiers. Public
+keys can be supplied as live `PGPKey` objects or ASCII-armored blobs using the
+following recipient `KeyRef` forms:
+
+- `{"kind": "pgpy_pub", "pub": pgpy.PGPKey}`
+- `{"kind": "pgpy_pub_armored", "pub": "-----BEGIN PGP PUBLIC KEY-----"}`
+- `{"kind": "pgpy_key", "key": pgpy.PGPKey}` (sealed CEK helper that lifts
+  the public subkey from a combined key object)
+
+Use these identity `KeyRef` forms when opening envelopes:
+
+- `{"kind": "pgpy_priv", "priv": pgpy.PGPKey}`
+- `{"kind": "pgpy_priv_armored", "priv": "-----BEGIN PGP PRIVATE KEY-----"}`
+- `{"kind": "pgpy_key", "key": pgpy.PGPKey}` (sealed CEK provider)
+- `{"kind": "pgpy_key_armored", "key": "-----BEGIN PGP PRIVATE KEY-----"}`
+
+Private keys may be locked; pass the unlocking secret in `opts["passphrase"]`.
 
 ### Installation
 
+Install the provider with your preferred packaging tool:
+
 ```bash
+# pip
 pip install swarmauri_mre_crypto_pgp
+
+# Poetry
+poetry add swarmauri_mre_crypto_pgp
+
+# uv (project dependency)
+uv add swarmauri_mre_crypto_pgp
+
+# uv (virtualenv-only install)
+uv pip install swarmauri_mre_crypto_pgp
 ```
 
 ### Usage
@@ -78,8 +118,27 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+### Selecting modes
+
+`PGPMreCrypto` defaults to `MreMode.ENC_ONCE_HEADERS`. Pass
+`mode=MreMode.SEALED_PER_RECIPIENT` (or the string value) to switch to the
+sealed-per-recipient variant. `PGPSealedCekMreCrypto` always operates in the
+`sealed_cek+aead` mode and will raise when the envelope mode or algorithms do
+not match the expected values.
+
+### Re-wrapping envelopes
+
+- **Sealed per recipient** – Re-wrapping with additional recipients requires
+  `opts["plaintext"]` so the providers can seal the original payload again.
+- **Shared CEK (enc_once / sealed_cek)** – Supply either the decrypted CEK via
+  `opts["cek"]` or provide identities capable of opening the envelope through
+  `opts["manage_key"]` (composite provider) or
+  `opts["opener_identities"]` (sealed CEK provider).
+  Enable payload rotation with `opts["rotate_payload_on_revoke"]` to generate a
+  fresh CEK when removing recipients.
+
 ## Entry point
 
-Providers are registered under the `swarmauri.mre_cryptos` entry-point as
-`PGPSealMreCrypto`, `PGPSealedCekMreCrypto` and `PGPMreCrypto`.
+Providers are registered under the `swarmauri.mre_cryptos` entry point as
+`PGPSealMreCrypto`, `PGPSealedCekMreCrypto`, and `PGPMreCrypto`.
 


### PR DESCRIPTION
## Summary
- align the Swarmauri MRE Crypto PGP README with the current provider behavior and key reference options
- document pip, Poetry, and uv installation paths including guidance for project dependency management

## Testing
- uv run --directory pkgs/standards/swarmauri_mre_crypto_pgp --package swarmauri_mre_crypto_pgp ruff format .
- uv run --directory pkgs/standards/swarmauri_mre_crypto_pgp --package swarmauri_mre_crypto_pgp ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_mre_crypto_pgp --package swarmauri_mre_crypto_pgp pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7872fe2c83319d03e640f16ddeb7