### PR TITLE
Align webhook publisher README with behavior and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_publisher_webhook/README.md
+++ b/pkgs/standards/swarmauri_publisher_webhook/README.md
@@ -18,12 +18,25 @@
 
 # Swarmauri Webhook Publisher
 
-A Swarmauri component for publishing messages to an HTTP webhook endpoint.
+`WebhookPublisher` is a Swarmauri component that delivers JSON events to an HTTP
+endpoint. It keeps an internal `httpx.Client` session for efficient reuse and
+raises a `RuntimeError` when the webhook cannot be reached or responds with a
+non-success status code.
 
 ## Installation
 
+Choose the tool that fits your workflow:
+
 ```bash
+# pip
 pip install swarmauri_publisher_webhook
+
+# Poetry
+poetry add swarmauri_publisher_webhook
+
+# uv (install the tool if you do not already have it)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv add swarmauri_publisher_webhook
 ```
 
 ## Usage
@@ -38,3 +51,7 @@ publisher.publish(
     payload={"message": "Hello, webhook!", "value": 123}
 )
 ```
+
+The publisher posts a JSON object shaped as `{"channel": ..., "payload": ...}`
+to the configured URL. Wrap calls to `publish` in your own error handling if you
+need to catch connectivity or webhook-side failures.

--- a/pkgs/standards/swarmauri_publisher_webhook/pyproject.toml
+++ b/pkgs/standards/swarmauri_publisher_webhook/pyproject.toml
@@ -36,6 +36,7 @@ markers = [
     "unit: Unit tests",
     "i9n: Integration tests",
     "r8n: Regression tests",
+    "example: Example usage tests",
     "timeout: mark test to timeout after X seconds",
     "xpass: Expected passes",
     "xfail: Expected failures",

--- a/pkgs/standards/swarmauri_publisher_webhook/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_publisher_webhook/tests/example/test_readme_example.py
@@ -1,0 +1,43 @@
+"""Execute the usage example from the README to guard against regressions."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from swarmauri_publisher_webhook import WebhookPublisher
+
+
+@pytest.mark.example
+def test_readme_usage_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the documented quickstart and assert the emitted payload."""
+
+    recorded: dict[str, object] = {}
+
+    def fake_post(
+        self: httpx.Client,
+        url: str,
+        *,
+        json: dict[str, object],
+        **_: object,
+    ) -> httpx.Response:  # type: ignore[override]
+        recorded["url"] = url
+        recorded["json"] = json
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post, raising=True)
+
+    publisher = WebhookPublisher(url="https://your-webhook-endpoint.com/hook")
+
+    publisher.publish(
+        channel="my_data_stream",
+        payload={"message": "Hello, webhook!", "value": 123},
+    )
+
+    assert recorded == {
+        "url": "https://your-webhook-endpoint.com/hook",
+        "json": {
+            "channel": "my_data_stream",
+            "payload": {"message": "Hello, webhook!", "value": 123},
+        },
+    }


### PR DESCRIPTION
## Summary
- document the webhook publisher's runtime behaviour and extend installation guidance for Poetry and uv
- add the README quickstart test with an example marker registration to keep the documentation executable

## Testing
- uv run --directory pkgs/standards/swarmauri_publisher_webhook --package swarmauri_publisher_webhook pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7867180c8331983a32f82ae181b1