### PR TITLE
Update Redis publisher README and add example test

### DIFF
--- a/pkgs/standards/swarmauri_publisher_redis/README.md
+++ b/pkgs/standards/swarmauri_publisher_redis/README.md
@@ -18,20 +18,63 @@
 
 # Swarmauri Redis Publisher
 
-This package provides a Redis Pub/Sub publisher implementation conforming to the Swarmauri `PublishBase` interface.
+`swarmauri_publisher_redis` provides a Redis Pub/Sub publisher that conforms to the Swarmauri [`PublishBase`](https://github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_base) interface. The publisher serializes dictionaries to JSON before sending them to Redis channels, making it easy to exchange structured messages across your Swarmauri deployments.
 
 ## Installation
 
+Choose the workflow that matches your project setup:
+
 ```bash
-# Add installation instructions if applicable, e.g., pip install .
+# Using pip
+pip install swarmauri_publisher_redis
+
+# Using Poetry
+poetry add swarmauri_publisher_redis
+
+# Using uv (https://docs.astral.sh/uv/)
+uv add swarmauri_publisher_redis
+# or install into the active environment
+uv pip install swarmauri_publisher_redis
 ```
 
+## Configuration
+
+`RedisPublisher` accepts either a complete Redis connection URI or the individual connection settings. Mixing the two configuration styles is not supported.
+
+- `uri`: Full Redis URI such as `redis://[:password]@host:port/db`.
+- `host`, `port`, `db`: Required when `uri` is not provided. The publisher constructs the URI for you.
+- `username`, `password`: Optional credentials used when building the URI.
+
+If neither a URI nor the full host/port/db combination is supplied, initialization raises a `ValueError`.
+
 ## Usage
+
+The publisher creates a Redis client from your connection information and publishes JSON-encoded payloads.
 
 ```python
 from swarmauri_publisher_redis import RedisPublisher
 
-# Example usage
-publisher = RedisPublisher(host="localhost", port=6379, db=0)
+publisher = RedisPublisher(
+    host="localhost",
+    port=6379,
+    db=0,
+)
+
 publisher.publish("my_channel", {"message": "Hello Redis!"})
 ```
+
+### Using a Redis URI
+
+You can also configure the publisher with a pre-built connection string:
+
+```python
+from swarmauri_publisher_redis import RedisPublisher
+
+publisher = RedisPublisher(uri="redis://localhost:6379/0")
+publisher.publish("alerts", {"severity": "info", "detail": "It works!"})
+```
+
+## Additional Notes
+
+- Payloads are serialized with `json.dumps` before being sent to Redis.
+- A Redis server must be reachable for the publish call to succeed outside of tests.

--- a/pkgs/standards/swarmauri_publisher_redis/pyproject.toml
+++ b/pkgs/standards/swarmauri_publisher_redis/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: README and documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_publisher_redis/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_publisher_redis/tests/test_readme_example.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_quickstart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Execute the README quickstart example to ensure it stays valid."""
+    readme_path = Path(__file__).resolve().parents[1] / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    code_blocks = re.findall(r"```python\n(.*?)\n```", readme_text, re.DOTALL)
+    example_block = next(
+        (block for block in code_blocks if "RedisPublisher" in block),
+        None,
+    )
+
+    assert example_block is not None, (
+        "Could not find the README RedisPublisher example."
+    )
+
+    published_messages: list[tuple[str, str]] = []
+
+    def fake_from_url(*_args, **_kwargs) -> SimpleNamespace:
+        def _publish(channel: str, payload: str) -> None:
+            published_messages.append((channel, payload))
+
+        return SimpleNamespace(publish=_publish)
+
+    monkeypatch.setattr("redis.from_url", fake_from_url)
+
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(example_block, namespace)
+
+    assert published_messages, "README example did not publish any messages."
+
+    channel, payload = published_messages[0]
+    assert isinstance(channel, str)
+    assert isinstance(payload, str)
+    assert json.loads(payload)["message"] == "Hello Redis!"


### PR DESCRIPTION
## Summary
- expand the Redis publisher README with installation options, configuration guidance, and refreshed usage examples aligned with the implementation
- add a README-backed pytest that executes the documented quickstart example under a mocked Redis client and registers the `example` marker for pytest

## Testing
- uv run --directory pkgs/standards/swarmauri_publisher_redis --package swarmauri_publisher_redis pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7865e2d483318fc8debcd7ddc92c