### PR TITLE
Document middleware behavior and test README example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_securityheaders/README.md
+++ b/pkgs/standards/swarmauri_middleware_securityheaders/README.md
@@ -24,21 +24,71 @@
 
 Middleware for adding security-focused HTTP headers to FastAPI responses, helping shield applications from common web vulnerabilities.
 
+## What it does
+
+`SecurityHeadersMiddleware` ensures every response produced by your FastAPI
+application carries the following headers and values:
+
+- `Content-Security-Policy`: `default-src 'self'; script-src 'self'
+  https://cdn.example.com; style-src 'self' https://cdn.example.com; img-src
+  'self' https://images.example.com; font-src 'self'
+  https://fonts.example.com`
+- `X-Content-Type-Options`: `nosniff`
+- `X-Frame-Options`: `DENY`
+- `X-XSS-Protection`: `1; mode=block`
+- `Strict-Transport-Security`: `max-age=31536000; includeSubDomains; preload`
+- `Referrer-Policy`: `same-origin`
+- `Permissions-Policy`: `interest-cohort=(), geolocation=(self),
+  microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(self),
+  vibrate=(), payment=()`
+
+These defaults provide a strong baseline for many applications. Update the
+middleware if you need to tailor the directives (for example, to change the
+allowed host names in the Content Security Policy).
+
 ## Installation
+
+### pip
 
 ```bash
 pip install swarmauri-middleware-securityheaders
 ```
 
+### Poetry
+
+```bash
+poetry add swarmauri_middleware_securityheaders
+```
+
+### uv
+
+```bash
+uv add swarmauri_middleware_securityheaders
+```
+
 ## Usage
 
 ```python
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from swarmauri_middleware_securityheaders import SecurityHeadersMiddleware
 
 app = FastAPI()
-app.add_middleware(SecurityHeadersMiddleware)
+security_middleware = SecurityHeadersMiddleware(app)
+
+
+@app.middleware("http")
+async def apply_security_headers(request: Request, call_next):
+    return await security_middleware.dispatch(request, call_next)
+
+
+@app.get("/")
+async def read_root() -> dict[str, str]:
+    return {"status": "ok"}
 ```
+
+This pattern instantiates the middleware once and reuses its `dispatch` method
+within FastAPI's `@app.middleware("http")` hook so that every response includes
+the security headers listed above.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_middleware_securityheaders/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_securityheaders/pyproject.toml
@@ -34,6 +34,7 @@ markers = [
     "test: standard test",
     "unit: Unit tests",
     "i9n: Integration tests",
+    "example: Documentation-backed examples",
     "r8n: Regression tests",
     "timeout: mark test to timeout after X seconds",
     "xpass: Expected passes",

--- a/pkgs/standards/swarmauri_middleware_securityheaders/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_securityheaders/tests/test_readme_example.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+
+from swarmauri_middleware_securityheaders import SecurityHeadersMiddleware
+
+
+CODE_BLOCK_PATTERN = re.compile(r"```python\n(?P<code>.*?)\n```", re.DOTALL)
+
+
+@pytest.mark.example
+def test_readme_usage_example_executes() -> None:
+    """Execute the README usage example and confirm headers are applied."""
+
+    readme_path = Path(__file__).resolve().parents[1] / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    match = CODE_BLOCK_PATTERN.search(readme_text)
+    assert match is not None, "Could not locate python example in README.md"
+
+    namespace: dict[str, Any] = {}
+    exec(match.group("code"), namespace)
+
+    app = namespace.get("app")
+    assert isinstance(app, FastAPI), "README example did not define a FastAPI app"
+
+    client = TestClient(app)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+    control_response = Response()
+
+    def _dummy_app(*args: Any, **kwargs: Any) -> Response:
+        return control_response
+
+    SecurityHeadersMiddleware(_dummy_app)._add_security_headers(control_response)
+
+    expected_headers = {
+        header: value
+        for header, value in control_response.headers.items()
+        if header
+        in {
+            "Content-Security-Policy",
+            "X-Content-Type-Options",
+            "X-Frame-Options",
+            "X-XSS-Protection",
+            "Strict-Transport-Security",
+            "Referrer-Policy",
+            "Permissions-Policy",
+        }
+    }
+
+    for header, expected_value in expected_headers.items():
+        assert response.headers.get(header) == expected_value


### PR DESCRIPTION
## Summary
- expand the README to document the exact headers added by `SecurityHeadersMiddleware`, add pip/poetry/uv installation guidance, and show how to reuse the middleware's `dispatch` hook with FastAPI
- register the `example` pytest mark for this package and add a README-driven integration test that executes the documented example and validates the injected headers

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_securityheaders --package swarmauri_middleware_securityheaders ruff format .
- uv run --directory pkgs/standards/swarmauri_middleware_securityheaders --package swarmauri_middleware_securityheaders ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_middleware_securityheaders --package swarmauri_middleware_securityheaders pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca785195fc8331b534cd1bd2babdf2