### PR TITLE
Document BeautifulSoup parser behavior and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_parser_beautifulsoupelement/README.md
+++ b/pkgs/standards/swarmauri_parser_beautifulsoupelement/README.md
@@ -18,20 +18,44 @@
 
 # Swarmauri Parser Beautifulsoupelement
 
-A specialized parser that utilizes BeautifulSoup to extract specific HTML elements and their content from HTML documents.
+A specialized parser that utilizes BeautifulSoup to extract specific HTML elements and their content from HTML documents. The parser accepts HTML strings only and produces a list of `Document` objects that capture both the HTML snippet for each matched element and metadata (the element tag and its index within the input).
 
 ## Installation
+
+Choose the installation workflow that fits your project:
+
+### pip
 
 ```bash
 pip install swarmauri_parser_beautifulsoupelement
 ```
 
+### Poetry
+
+```bash
+poetry add swarmauri_parser_beautifulsoupelement
+```
+
+### uv
+
+If you have not installed `uv` yet, grab it with the official installer:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Once `uv` is available, add the parser to your environment:
+
+```bash
+uv pip install swarmauri_parser_beautifulsoupelement
+```
+
 ## Usage
 
-The BeautifulSoupElementParser allows you to extract specific HTML elements from HTML content:
+The `BeautifulSoupElementParser` allows you to extract specific HTML elements from HTML content:
 
 ```python
-from swarmauri_parser_beautifulsoupelement.BeautifulSoupElementParser import BeautifulSoupElementParser
+from swarmauri_parser_beautifulsoupelement import BeautifulSoupElementParser
 
 # Create a parser instance to extract paragraphs
 parser = BeautifulSoupElementParser(element="p")
@@ -39,13 +63,16 @@ parser = BeautifulSoupElementParser(element="p")
 # HTML content to parse
 html_content = "<div><p>First paragraph</p><p>Second paragraph</p></div>"
 
-# Parse the content
+# Parse the content (input must be a string)
 documents = parser.parse(html_content)
 
-# Access the extracted elements
+# Access the extracted elements and metadata
 for doc in documents:
-    print(doc.content)  # Prints each paragraph element
+    print(doc.content)     # Prints each paragraph element, including the surrounding <p> tag
+    print(doc.metadata)    # {'element': 'p', 'index': 0}, {'element': 'p', 'index': 1}, ...
 ```
+
+> **Note:** `BeautifulSoupElementParser.parse` raises a `ValueError` if the provided `data` argument is not a string. Ensure that you pass HTML content as a text string before invoking the parser.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_parser_beautifulsoupelement/pyproject.toml
+++ b/pkgs/standards/swarmauri_parser_beautifulsoupelement/pyproject.toml
@@ -37,6 +37,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_parser_beautifulsoupelement/tests/test_readme_examples.py
+++ b/pkgs/standards/swarmauri_parser_beautifulsoupelement/tests/test_readme_examples.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.example
+def test_usage_example_from_readme():
+    """Execute the README usage example to ensure it stays valid."""
+
+    readme_path = Path(__file__).resolve().parent.parent / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    # Pull the first Python code block from the README (the usage example).
+    match = re.search(r"```python\n(.*?)```", readme_text, re.DOTALL)
+    assert match, "Expected to find a Python code block in the README."
+
+    code_block = match.group(1)
+
+    namespace: dict[str, object] = {}
+    exec(code_block, namespace)  # noqa: S102 - executing trusted documentation example
+
+    documents = namespace.get("documents")
+    assert documents is not None, (
+        "The README example should define a 'documents' variable."
+    )
+
+    # Validate that the parser extracted <p> elements with accompanying metadata.
+    contents = [doc.content for doc in documents]
+    metadata = [doc.metadata for doc in documents]
+
+    assert contents == ["<p>First paragraph</p>", "<p>Second paragraph</p>"]
+    assert metadata == [
+        {"element": "p", "index": 0},
+        {"element": "p", "index": 1},
+    ]


### PR DESCRIPTION
## Summary
- clarify the BeautifulSoup parser documentation to reflect HTML-only input, returned metadata, and expanded installation options including Poetry and uv
- add a pytest mark for documentation examples and execute the README usage snippet during tests to keep the example current

## Testing
- uv run --directory pkgs/standards/swarmauri_parser_beautifulsoupelement --package swarmauri_parser_beautifulsoupelement pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7868a9fc833192ebb1c8e9958a77