### PR TITLE
Document RabbitMQ publisher usage and back it with a README test

### DIFF
--- a/pkgs/standards/swarmauri_publisher_rabbitmq/README.md
+++ b/pkgs/standards/swarmauri_publisher_rabbitmq/README.md
@@ -18,31 +18,90 @@
 
 # Swarmauri RabbitMQ Publisher
 
-This package provides a RabbitMQ publisher implementation conforming to the Swarmauri `PublishBase` interface.
+`RabbitMQPublisher` is the Swarmauri `PublishBase` implementation for RabbitMQ. The publisher opens a `pika.BlockingConnection`, ensures the target exchange exists, and emits JSON payloads using persistent delivery semantics.
+
+## Highlights
+
+- Configure using either a full AMQP URI or discrete host/port credential fields. Supplying both styles raises `ValueError`.
+- Declares the target exchange as a durable direct exchange during instantiation.
+- Serializes payloads with `json.dumps` and publishes with `delivery_mode=pika.spec.PERSISTENT_DELIVERY_MODE` so messages survive broker restarts.
+- On `pika.exceptions.AMQPConnectionError` or `ChannelClosedByBroker` the publisher reconnects once, re-declares the exchange, and retries the publish.
 
 ## Installation
 
-This package is part of the Swarmauri SDK monorepo.
+Choose the tool that fits your workflow:
 
-## Usage
+```bash
+# pip
+pip install swarmauri_publisher_rabbitmq
+
+# Poetry
+poetry add swarmauri_publisher_rabbitmq
+
+# uv
+uv add swarmauri_publisher_rabbitmq
+```
+
+## Configuration
+
+`RabbitMQPublisher` extends `PublishBase` and supports the following fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `exchange` | ✅ | The exchange name to declare and publish to. Declared as a durable direct exchange. |
+| `uri` | ⚪️ | Full AMQP URI. When provided, omit `host`/`port`/`username`/`password`. |
+| `host` | ⚪️ | RabbitMQ host. Required when `uri` is omitted. |
+| `port` | ⚪️ | RabbitMQ port. Supply the broker port (for example `5672`); the publisher does not insert a default when constructing the URI. |
+| `username` | ⚪️ | Username used in the URI when `uri` is omitted. Automatically URL-encoded. |
+| `password` | ⚪️ | Password used in the URI when `uri` is omitted. Automatically URL-encoded. |
+
+The `publish(channel, payload)` method treats `channel` as the RabbitMQ routing key. `payload` must be JSON serialisable because it is serialized with `json.dumps` before publishing.
+
+## Quickstart
+
+Ensure RabbitMQ is reachable and that you have permission to declare the exchange. The example below shows the host/port configuration path.
 
 ```python
+# README Quickstart Example
 from swarmauri_publisher_rabbitmq import RabbitMQPublisher
 
-# Example usage with host/port
 publisher = RabbitMQPublisher(
     host="localhost",
     port=5672,
     username="guest",
     password="guest",
-    exchange="my_exchange"
+    exchange="demo_exchange",
 )
-publisher.publish(channel="my_routing_key", payload={"message": "Hello RabbitMQ!"})
 
-# Example usage with URI
-# publisher_uri = RabbitMQPublisher(
-#     uri="amqp://guest:guest@localhost:5672/",
-#     exchange="my_exchange"
-# )
-# publisher_uri.publish(channel="my_routing_key", payload={"message": "Hello via URI!"})
+publisher.publish(
+    channel="demo.routing.key",
+    payload={"message": "Hello RabbitMQ!"},
+)
 ```
+
+The constructor builds the AMQP URI from the supplied parts, opens a blocking connection, and declares `demo_exchange` as a durable direct exchange. Each call to `publish` JSON-encodes the payload and requests persistent delivery so the message survives broker restarts.
+
+### Connecting with an AMQP URI
+
+If you already have an AMQP URI, provide it directly and omit the individual connection fields:
+
+```python
+from swarmauri_publisher_rabbitmq import RabbitMQPublisher
+
+publisher = RabbitMQPublisher(
+    uri="amqp://guest:guest@localhost:5672/",
+    exchange="demo_exchange",
+)
+
+publisher.publish(
+    channel="demo.routing.key",
+    payload={"message": "Hello RabbitMQ via URI!"},
+)
+```
+
+## Behavior notes
+
+- Credentials are URL-encoded via `urllib.parse.quote_plus` when constructing an AMQP URI from discrete fields, and a username can be supplied without a password if the broker permits it.
+- `pika.BasicProperties` is called with `delivery_mode=pika.spec.PERSISTENT_DELIVERY_MODE`.
+- If RabbitMQ closes the channel or the connection drops, the publisher closes the connection, recreates it with the original URI, re-declares the exchange, and retries the publish once.
+- When the publisher instance is garbage-collected it closes the open connection if it is still active.

--- a/pkgs/standards/swarmauri_publisher_rabbitmq/pyproject.toml
+++ b/pkgs/standards/swarmauri_publisher_rabbitmq/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "unit: Unit tests",
     "i9n: Integration tests",
     "r8n: Regression tests",
+    "example: Example usage tests",
     "timeout: mark test to timeout after X seconds",
     "xpass: Expected passes",
     "xfail: Expected failures",

--- a/pkgs/standards/swarmauri_publisher_rabbitmq/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_publisher_rabbitmq/tests/test_readme_example.py
@@ -1,0 +1,98 @@
+"""Execute the README quickstart to guard against drift."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_quickstart_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The README quickstart should continue to represent the real API."""
+
+    readme_path = Path(__file__).resolve().parent.parent / "README.md"
+    quickstart = _load_readme_quickstart(readme_path)
+
+    publisher_module = importlib.import_module(
+        "swarmauri_publisher_rabbitmq.RabbitMQPublisher"
+    )
+
+    published_messages: list[Dict[str, Any]] = []
+    created_uris: list[str] = []
+
+    class DummyChannel:
+        def __init__(self) -> None:
+            self.exchange_declarations: list[Dict[str, Any]] = []
+
+        def exchange_declare(self, **kwargs: Any) -> None:
+            self.exchange_declarations.append(dict(kwargs))
+
+        def basic_publish(self, **kwargs: Any) -> None:
+            published_messages.append(dict(kwargs))
+
+    class DummyConnection:
+        def __init__(self, params: Any) -> None:
+            self.params = params
+            self._closed = False
+            self._channel = DummyChannel()
+
+        def channel(self) -> DummyChannel:
+            return self._channel
+
+        def close(self) -> None:
+            self._closed = True
+
+        @property
+        def is_closed(self) -> bool:  # pragma: no cover - trivial accessor
+            return self._closed
+
+    class DummyURLParameters:
+        def __init__(self, uri: str) -> None:
+            self.uri = uri
+            created_uris.append(uri)
+
+    class DummyBasicProperties:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(publisher_module.pika, "URLParameters", DummyURLParameters)
+    monkeypatch.setattr(publisher_module.pika, "BlockingConnection", DummyConnection)
+    monkeypatch.setattr(publisher_module.pika, "BasicProperties", DummyBasicProperties)
+
+    namespace: Dict[str, Any] = {"__builtins__": __builtins__}
+    exec(quickstart, namespace)
+
+    publisher = namespace["publisher"]
+    assert publisher.exchange == "demo_exchange"
+    assert publisher._connection.params.uri == "amqp://guest:guest@localhost:5672/"
+    assert publisher._channel.exchange_declarations == [
+        {"exchange": "demo_exchange", "exchange_type": "direct", "durable": True}
+    ]
+
+    assert created_uris == ["amqp://guest:guest@localhost:5672/"]
+    assert len(published_messages) == 1
+    message = published_messages[0]
+    assert message["exchange"] == "demo_exchange"
+    assert message["routing_key"] == "demo.routing.key"
+    assert json.loads(message["body"].decode("utf-8")) == {"message": "Hello RabbitMQ!"}
+    assert message["properties"].kwargs["delivery_mode"] == (
+        publisher_module.pika.spec.PERSISTENT_DELIVERY_MODE
+    )
+
+
+def _load_readme_quickstart(readme_path: Path) -> str:
+    """Extract the quickstart snippet from the README."""
+
+    text = readme_path.read_text(encoding="utf-8")
+    match = re.search(
+        r"```python\n(?P<code>.*?# README Quickstart Example.*?)\n```",
+        text,
+        re.DOTALL,
+    )
+    assert match, "Could not locate the README quickstart code block."
+    return match.group("code")


### PR DESCRIPTION
## Summary
- refresh the RabbitMQ publisher README with accurate behavior notes and pip/Poetry/uv installation guidance
- add a pytest that executes the README quickstart example against mocked pika primitives
- register the `example` marker in the package configuration so pytest recognises the new test label

## Testing
- uv run --directory pkgs/standards/swarmauri_publisher_rabbitmq --package swarmauri_publisher_rabbitmq ruff format .
- uv run --directory pkgs/standards/swarmauri_publisher_rabbitmq --package swarmauri_publisher_rabbitmq ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_publisher_rabbitmq --package swarmauri_publisher_rabbitmq pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78650a6883318113a35c1a5f10d9