### PR TITLE
docs: update session middleware README example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_session/README.md
+++ b/pkgs/standards/swarmauri_middleware_session/README.md
@@ -22,13 +22,90 @@
 
 # Swarmauri Middleware Session
 
-Session middleware for maintaining session state across requests.
+Session middleware for FastAPI and Starlette style applications that keeps a
+lightweight, in-memory session store synchronized with every request and
+response.
+
+## Overview
+
+- Accepts an incoming session identifier from the `X-Session-ID` request header
+  (customisable through `session_header`).
+- Falls back to generating a new UUID session identifier and persists it on the
+  response when none is supplied.
+- Stores per-session data in `session_storage`, allowing subsequent requests to
+  reuse state keyed by the same identifier.
+- Writes the active session id to `request.state.session_id` and mirrors it in
+  the `session_id` response cookie (customisable through `session_cookie`).
+- Uses a configurable `max_age` to control the lifetime of the emitted cookie.
 
 ## Installation
+
+Install from PyPI using the toolchain that fits your workflow.
+
+### pip
 
 ```bash
 pip install swarmauri_middleware_session
 ```
+
+### Poetry
+
+```bash
+poetry add swarmauri_middleware_session
+```
+
+### uv
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install swarmauri_middleware_session
+```
+
+## Example
+
+```python
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from swarmauri_middleware_session import SessionMiddleware
+
+
+app = FastAPI()
+session_middleware = SessionMiddleware()
+
+
+@app.middleware("http")
+async def attach_session(request: Request, call_next):
+    return await session_middleware.dispatch(request, call_next)
+
+
+@app.get("/greet")
+async def greet(request: Request):
+    session_id = request.state.session_id
+    session_data = session_middleware.session_storage.setdefault(session_id, {})
+    session_data["visits"] = session_data.get("visits", 0) + 1
+    return JSONResponse({"session_id": session_id, "visits": session_data["visits"]})
+
+
+client = TestClient(app)
+
+first_response = client.get("/greet")
+first_data = first_response.json()
+
+second_response = client.get(
+    "/greet", headers={"X-Session-ID": first_response.headers["X-Session-ID"]}
+)
+second_data = second_response.json()
+
+print(first_data)
+print(second_data)
+```
+
+Running the example prints the initial visit count followed by an incremented
+visit count for the same session, demonstrating how the middleware keeps track
+of state across requests.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_middleware_session/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_session/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_session/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_session/tests/test_readme_example.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
+
+
+@pytest.mark.example
+def test_readme_python_example_executes(capsys):
+    """Execute the README example to ensure it remains up to date."""
+
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    match = re.search(r"```python\n(?P<code>.*?)```", readme_text, re.DOTALL)
+    assert match, "Python example not found in README.md"
+
+    namespace: dict[str, object] = {}
+    exec(compile(match.group("code"), str(README_PATH), "exec"), namespace)  # noqa: S102
+
+    captured_lines = capsys.readouterr().out.strip().splitlines()
+    assert len(captured_lines) == 2, captured_lines
+
+    first_data = namespace["first_data"]
+    second_data = namespace["second_data"]
+
+    assert isinstance(first_data, dict)
+    assert isinstance(second_data, dict)
+    assert first_data["session_id"] == second_data["session_id"]
+    assert first_data["visits"] == 1
+    assert second_data["visits"] == 2
+    assert captured_lines[0].strip() == str(first_data)
+    assert captured_lines[1].strip() == str(second_data)


### PR DESCRIPTION
## Summary
- expand the session middleware README with detailed behaviour notes and installation instructions for pip, Poetry, and uv
- add a runnable FastAPI example that illustrates session reuse across requests
- register an `example` pytest marker and add a README-backed test that executes the documented example

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_session --package swarmauri_middleware_session pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7850f3d48331912d6df57b0ee338