### PR TITLE
Align stdio middleware README with behavior and add README test

### DIFF
--- a/pkgs/standards/swarmauri_middleware_stdio/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_stdio/pyproject.toml
@@ -34,6 +34,7 @@ markers = [
     "test: standard test",
     "unit: Unit tests",
     "i9n: Integration tests",
+    "example: Example usage tests",
     "r8n: Regression tests",
     "timeout: mark test to timeout after X seconds",
     "xpass: Expected passes",

--- a/pkgs/standards/swarmauri_middleware_stdio/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_stdio/tests/example/test_readme_example.py
@@ -1,0 +1,41 @@
+import logging
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _load_usage_example() -> str:
+    readme_path = Path(__file__).resolve().parents[2] / "README.md"
+    content = readme_path.read_text(encoding="utf-8")
+    match = re.search(r"```python\n(.*?)```", content, re.DOTALL)
+    if not match:
+        raise AssertionError("Usage example code block not found in README.md")
+    return textwrap.dedent(match.group(1))
+
+
+@pytest.mark.example
+def test_readme_usage_example(caplog: pytest.LogCaptureFixture) -> None:
+    source = _load_usage_example()
+    namespace: dict[str, object] = {}
+    exec(source, namespace)  # noqa: S102 - executing README example
+
+    app = namespace.get("app")
+    if app is None:
+        raise AssertionError("README example did not define an 'app' instance")
+
+    with caplog.at_level(logging.INFO):
+        client = TestClient(app)
+        response = client.get("/")
+
+    assert response.json() == {"message": "hello"}
+
+    middleware_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "swarmauri_middleware_stdio.StdioMiddleware"
+    ]
+    assert any("STDIO Request: GET /" in message for message in middleware_logs)
+    assert any("STDIO Response: 200" in message for message in middleware_logs)


### PR DESCRIPTION
## Summary
- expand the Swarmauri stdio middleware README with pip/Poetry/uv installation guidance and clarify the logging example/output
- register a pytest `example` marker and add a README-backed example test that executes the documented FastAPI usage

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_stdio --package swarmauri_middleware_stdio ruff format .
- uv run --directory pkgs/standards/swarmauri_middleware_stdio --package swarmauri_middleware_stdio ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_middleware_stdio --package swarmauri_middleware_stdio pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca784fd530833191f6edbbc2cec114