### PR TITLE
Align keyword extractor README with implementation

### DIFF
--- a/pkgs/standards/swarmauri_parser_keywordextractor/README.md
+++ b/pkgs/standards/swarmauri_parser_keywordextractor/README.md
@@ -18,30 +18,53 @@
 
 # Swarmauri Parser Keywordextractor
 
-A parser component that extracts keywords from text using the YAKE keyword extraction library.
+`KeywordExtractorParser` wraps the [YAKE](https://github.com/LIAAD/yake) keyword
+extraction library to turn arbitrary text into a ranked list of
+`swarmauri_standard.documents.Document` instances. Each returned document stores
+the detected keyword in `content` and the YAKE importance score in
+`metadata["score"]`.
+
+The parser normalizes any input into a string before analysis and, by default,
+extracts up to 10 keywords using the English language model, three-word maximum
+phrases, and YAKE's sequence-matching deduplication (`dedupLim=0.9`). Override
+`lang` or `num_keywords` when instantiating the parser to tailor the output to
+your dataset.
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_parser_keywordextractor
+
+# Poetry
+poetry add swarmauri_parser_keywordextractor
+
+# uv
+uv add swarmauri_parser_keywordextractor
 ```
 
 ## Usage
-Here's a basic example of how to use the KeywordExtractorParser:
+
+Here's a basic example of how to use the `KeywordExtractorParser`:
+
 ```python
-from swarmauri_parser_keywordextractor.KeywordExtractorParser import KeywordExtractorParser
+from swarmauri_parser_keywordextractor import KeywordExtractorParser
 
-# Initialize the parser
-parser = KeywordExtractorParser()
+# Initialize the parser for three keywords in English
+parser = KeywordExtractorParser(num_keywords=3, lang="en")
 
-# Parse text and extract keywords
 text = "Artificial intelligence and machine learning are transforming technology"
 documents = parser.parse(text)
 
-# Access extracted keywords and their scores
-for doc in documents:
-    print(f"Keyword: {doc.content}, Score: {doc.metadata['score']}")
+for document in documents:
+    score = document.metadata["score"]
+    print(f"Keyword: {document.content}, Score: {score:.4f}")
 ```
+
+Each call to `parse` returns a list of `Document` objects ranked by YAKE so you
+can feed them directly into downstream Swarmauri pipelines.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_parser_keywordextractor/pyproject.toml
+++ b/pkgs/standards/swarmauri_parser_keywordextractor/pyproject.toml
@@ -37,6 +37,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_parser_keywordextractor/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_parser_keywordextractor/tests/example/test_readme_example.py
@@ -1,0 +1,26 @@
+"""Execute the README usage example to ensure it stays in sync."""
+
+import pytest
+
+from swarmauri_parser_keywordextractor import KeywordExtractorParser
+
+
+@pytest.mark.example
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Artificial intelligence and machine learning are transforming technology",
+    ],
+)
+def test_readme_usage_example(text: str) -> None:
+    parser = KeywordExtractorParser(num_keywords=3, lang="en")
+
+    documents = parser.parse(text)
+
+    assert len(documents) == 3
+    for document in documents:
+        assert document.content
+        assert "score" in document.metadata
+        score = document.metadata["score"]
+        assert score is not None
+        float(score)


### PR DESCRIPTION
## Summary
- explain how KeywordExtractorParser normalizes text, extracts ranked Document objects, and document the adjustable parameters
- add installation guidance for pip, Poetry, and uv in the README and update the usage example
- register the `example` mark and add a README-backed pytest that exercises the documented example

## Testing
- uv run --directory pkgs/standards/swarmauri_parser_keywordextractor --package swarmauri_parser_keywordextractor pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca786419548331b887899314c94650