### PR TITLE
docs: document github release storage adapter usage

### DIFF
--- a/pkgs/standards/swarmauri_storage_github_release/README.md
+++ b/pkgs/standards/swarmauri_storage_github_release/README.md
@@ -18,27 +18,130 @@
 
 # Swarmauri GitHub Release Storage Adapter
 
-Stores artifacts as assets on a GitHub release for use with Peagen.
+Stores and retrieves artifacts as assets on a GitHub release. The adapter is
+designed to plug directly into the Swarmauri/Peagen storage interfaces while
+still being usable as a standalone utility.
+
+## Features
+
+- **Automatic release management** – a release is created on-demand when the
+  requested tag does not already exist.
+- **`ghrel://` addressing** – the adapter exposes a `root_uri` and returns
+  fully-qualified URIs (e.g. `ghrel://org/repo/tag/path`) from `upload` calls.
+- **Prefix-aware paths** – supply an optional `prefix` to group related assets
+  underneath a pseudo-directory on the release.
+- **Bulk helpers** – use `upload_dir` and `download_dir` to synchronise entire
+  directories, or `iter_prefix` to discover stored assets.
+- **Configuration friendly** – `GithubReleaseStorageAdapter.from_uri` reads
+  credentials from `peagen.toml` (via `storage.adapters.gh_release.token`) or
+  the `GITHUB_TOKEN` environment variable, enabling zero-code configuration in
+  workflows.
+
+## Requirements
+
+- A GitHub personal access token (PAT) or GitHub App token with sufficient
+  permissions to view, create and manage releases on the target repository.
+- Network access to the GitHub REST API (provided by `PyGithub`).
+- Python 3.10 through 3.12.
 
 ## Installation
 
+### Install uv (optional)
+
 ```bash
-# pip install swarmauri_storage_github_release (when published)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+### Add the package with uv
+
+```bash
+uv add swarmauri_storage_github_release
+```
+
+### Add with Poetry
+
+```bash
+poetry add swarmauri_storage_github_release
+```
+
+### Install with pip
+
+```bash
+pip install swarmauri_storage_github_release
 ```
 
 ## Usage
 
 ```python
-from swarmauri_storage_github_release import GithubReleaseStorageAdapter
+from io import BytesIO
+
 from pydantic import SecretStr
-import io
+
+from swarmauri_storage_github_release import GithubReleaseStorageAdapter
 
 adapter = GithubReleaseStorageAdapter(
-    token=SecretStr("ghp_..."),
-    org="my-org",
-    repo="my-repo",
+    token=SecretStr("ghp_example-token"),
+    org="example-org",
+    repo="example-repo",
     tag="v1.0.0",
+    prefix="artifacts",
+    release_name="Example release",
+    message="Artifacts published by our workflow.",
 )
-uri = adapter.upload("artifact.txt", io.BytesIO(b"data"))
+
+print(adapter.root_uri)
+
+uri = adapter.upload("artifact.txt", BytesIO(b"important payload"))
+downloaded_payload = adapter.download("artifact.txt").read()
+assets = list(adapter.iter_prefix(""))
+
 print(uri)
+print(downloaded_payload)
+print(assets)
 ```
+
+The code above demonstrates:
+
+- `SecretStr` support for securely passing tokens.
+- Automatic release creation when the `v1.0.0` tag does not exist.
+- Prefix-aware uploads that produce the URI
+  `ghrel://example-org/example-repo/v1.0.0/artifacts/artifacts/artifact.txt`
+  (the asset key itself contains the prefix, so it appears in the base URI and
+  the returned asset key).
+- Round-tripping an asset and enumerating stored keys via `iter_prefix`.
+
+## Working with directories
+
+Use the bulk helper methods to synchronise entire directory trees:
+
+```python
+adapter.upload_dir("dist", prefix="binaries")
+adapter.download_dir("binaries", "./downloads")
+```
+
+Both helpers respect the adapter-level prefix and will mirror nested folders.
+
+## Using `ghrel://` URIs and configuration
+
+The `from_uri` class method creates adapters from an address such as:
+
+```python
+adapter = GithubReleaseStorageAdapter.from_uri(
+    "ghrel://example-org/example-repo/v1.0.0/artifacts",
+)
+```
+
+When invoked this way the adapter resolves credentials from, in order:
+
+1. `storage.adapters.gh_release.token` in `peagen.toml`.
+2. The `GITHUB_TOKEN` environment variable.
+
+Any prefix encoded in the URI is respected, and the resulting instance exposes
+the same API shown above.
+
+### Controlling release metadata
+
+The constructor accepts additional keyword arguments to fine tune release
+creation, including `release_name`, `message`, `draft`, and `prerelease`. These
+parameters map directly to GitHub's release settings, allowing you to reuse the
+adapter for production, staging, or nightly build workflows.

--- a/pkgs/standards/swarmauri_storage_github_release/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_github_release/pyproject.toml
@@ -44,6 +44,7 @@ markers = [
     "unit: Unit tests",
     "i9n: Integration tests",
     "r8n: Regression tests",
+    "example: Documentation examples",
     "timeout: mark test to timeout after X seconds",
     "xpass: Expected passes",
     "xfail: Expected failures",

--- a/pkgs/standards/swarmauri_storage_github_release/tests/unit/test_readme_example.py
+++ b/pkgs/standards/swarmauri_storage_github_release/tests/unit/test_readme_example.py
@@ -1,0 +1,144 @@
+"""Ensure README examples remain executable."""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from swarmauri_storage_github_release import (
+    gh_release_storage_adapter as adapter_module,
+)
+
+
+@pytest.mark.example
+def test_usage_example_executes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Execute the primary README example to guard against regressions."""
+
+    readme_path = Path(__file__).resolve().parents[2] / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    match = re.search(r"```python\n(.*?)\n```", readme_text, flags=re.DOTALL)
+    assert match, "Unable to locate python example in README.md"
+
+    example_code = textwrap.dedent(match.group(1))
+
+    class DummyUnknownObjectException(Exception):
+        """Replacement for PyGithub's UnknownObjectException."""
+
+    monkeypatch.setattr(
+        adapter_module,
+        "UnknownObjectException",
+        DummyUnknownObjectException,
+    )
+
+    class DummyRequester:
+        """Minimal requester that serves uploaded asset payloads."""
+
+        def __init__(self) -> None:
+            self.asset_payloads: Dict[str, bytes] = {}
+
+        def requestBytes(self, method: str, url: str, headers: Dict[str, str]):  # noqa: N802 - PyGithub naming
+            return None, self.asset_payloads[url]
+
+    requester = DummyRequester()
+
+    class DummyAsset:
+        """Simple asset representation that cooperates with the adapter."""
+
+        def __init__(self, release: DummyRelease, name: str, data: bytes) -> None:  # type: ignore[name-defined]
+            self._release = release
+            self.name = name
+            self.url = f"https://example.invalid/{release.repo.full_name}/{name}"
+            requester.asset_payloads[self.url] = data
+
+        def delete_asset(self) -> None:
+            self._release.remove_asset(self.name)
+
+    class DummyRelease:
+        """Release facade storing uploaded assets in-memory."""
+
+        def __init__(
+            self, client: DummyGithub, repo: DummyRepo, tag: str, name: str
+        ) -> None:  # type: ignore[name-defined] # noqa: PLR0913
+            self._client = client
+            self.repo = repo
+            self.tag = tag
+            self.name = name
+            self._assets: Dict[str, DummyAsset] = {}
+
+        def get_assets(self):
+            return list(self._assets.values())
+
+        def upload_asset(self, path: str, name: str, label: str) -> None:  # noqa: ARG002 - label unused in stub
+            data = Path(path).read_bytes()
+            self._assets[name] = DummyAsset(self, name, data)
+
+        def remove_asset(self, name: str) -> None:
+            asset = self._assets.pop(name, None)
+            if asset:
+                requester.asset_payloads.pop(asset.url, None)
+
+    class DummyRepo:
+        """Repository wrapper that can create and fetch releases."""
+
+        def __init__(self, client: DummyGithub, full_name: str) -> None:  # type: ignore[name-defined]
+            self._client = client
+            self.full_name = full_name
+            self._releases: Dict[str, DummyRelease] = {}
+
+        def get_release(self, tag: str) -> DummyRelease:
+            if tag not in self._releases:
+                raise adapter_module.UnknownObjectException(tag)
+            return self._releases[tag]
+
+        def create_git_release(
+            self,
+            tag: str,
+            name: str,
+            message: str,
+            draft: bool,
+            prerelease: bool,
+        ) -> DummyRelease:  # noqa: ARG002
+            release = DummyRelease(self._client, self, tag, name)
+            self._releases[tag] = release
+            return release
+
+    class DummyOrg:
+        """Organization shim returning deterministic repositories."""
+
+        def __init__(self, client: DummyGithub, name: str) -> None:  # type: ignore[name-defined]
+            self._client = client
+            self._name = name
+            self._repos: Dict[str, DummyRepo] = {}
+
+        def get_repo(self, repo_name: str) -> DummyRepo:
+            return self._repos.setdefault(
+                repo_name,
+                DummyRepo(self._client, f"{self._name}/{repo_name}"),
+            )
+
+    class DummyGithub:
+        """Drop-in replacement for ``PyGithub.Github`` used in the example."""
+
+        def __init__(self, token: str) -> None:
+            self.token = token
+            self._Github__requester = requester
+            self._orgs: Dict[str, DummyOrg] = {}
+
+        def get_organization(self, name: str) -> DummyOrg:
+            return self._orgs.setdefault(name, DummyOrg(self, name))
+
+    monkeypatch.setattr(adapter_module, "Github", DummyGithub)
+
+    namespace: Dict[str, object] = {}
+    exec(compile(example_code, str(readme_path), "exec"), namespace)
+
+    assert namespace["uri"] == (
+        "ghrel://example-org/example-repo/v1.0.0/artifacts/artifacts/artifact.txt"
+    )
+    assert namespace["downloaded_payload"] == b"important payload"
+    assert namespace["assets"] == ["artifact.txt"]


### PR DESCRIPTION
## Summary
- expand the GitHub release storage README with feature highlights, installation guidance, and an executable usage example
- note prefix behaviour, directory helpers, and configuration via `ghrel://` URIs
- add a README-backed pytest marked as `example` and register the marker in `pyproject.toml`

## Testing
- uv run --directory pkgs/standards/swarmauri_storage_github_release --package swarmauri_storage_github_release pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca784572448331abb64e4cc3d538a4