### PR TITLE
Improve MinIO storage README and example coverage

### DIFF
--- a/pkgs/standards/swarmauri_storage_minio/README.md
+++ b/pkgs/standards/swarmauri_storage_minio/README.md
@@ -18,27 +18,77 @@
 
 # Swarmauri MinIO Storage Adapter
 
-Peagen storage adapter that saves artifacts to a MinIO or S3-compatible bucket.
+Peagen storage adapter that saves artifacts to a MinIO or any S3-compatible bucket using the official `minio` Python client.
+
+## Features
+
+- Automatically creates the target bucket if it does not already exist.
+- Optional `prefix` argument to scope uploads without changing your keys.
+- Implements `upload`, `download`, `upload_dir`, `download_dir`, and `iter_prefix` helpers for working with single files or directories.
+- Exposes a `root_uri` describing the bucket and prefix (`minio[s]://endpoint/bucket/prefix/`).
+- `MinioStorageAdapter.from_uri()` reads credentials from `peagen.toml` or the `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` environment variables for zero-copy configuration.
 
 ## Installation
 
+### Using uv
+
 ```bash
-# pip install swarmauri_storage_minio (when published)
+uv add swarmauri_storage_minio
+# or install into an existing environment
+uv pip install swarmauri_storage_minio
+```
+
+### Using Poetry
+
+```bash
+poetry add swarmauri_storage_minio
+```
+
+### Using pip
+
+```bash
+pip install swarmauri_storage_minio
 ```
 
 ## Usage
 
+The adapter wraps a MinIO client instance. When you instantiate it, the bucket is created if it does not already exist. Use the `secure` flag for HTTPS endpoints (`True` by default) and supply a `prefix` when you want to namespace all uploads under a directory.
+
 ```python
 from swarmauri_storage_minio import MinioStorageAdapter
-from pydantic import SecretStr
 import io
 
 adapter = MinioStorageAdapter(
     endpoint="localhost:9000",
-    access_key=SecretStr("minio"),
-    secret_key=SecretStr("minio123"),
+    access_key="minio",
+    secret_key="minio123",
     bucket="peagen",
+    secure=False,
+    prefix="examples/",
 )
 uri = adapter.upload("artifact.txt", io.BytesIO(b"data"))
 print(uri)
+
+downloaded = adapter.download("artifact.txt").read()
+print(downloaded.decode("utf-8"))
+```
+
+> **Note:** If you store credentials as `SecretStr`, call `.get_secret_value()` when passing them to the adapter.
+
+### Config-driven instantiation
+
+The adapter can also be created from a URI. Credentials are loaded from `peagen.toml` or environment variables.
+
+```toml
+# peagen.toml
+[storage.adapters.minio]
+access_key = "minio"
+secret_key = "minio123"
+```
+
+```python
+from swarmauri_storage_minio import MinioStorageAdapter
+
+adapter = MinioStorageAdapter.from_uri("minio://localhost:9000/peagen/examples/")
+print(adapter.root_uri)
 ```

--- a/pkgs/standards/swarmauri_storage_minio/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_minio/pyproject.toml
@@ -49,6 +49,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: README-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_storage_minio/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_storage_minio/tests/test_readme_example.py
@@ -1,0 +1,67 @@
+"""Ensure README examples stay in sync with the implementation."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+class _DummyObject:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def close(self) -> None:  # pragma: no cover - compatibility shim
+        pass
+
+    def release_conn(self) -> None:  # pragma: no cover - compatibility shim
+        pass
+
+
+class _DummyClient:
+    def __init__(self, *args, **kwargs):
+        self.objects: dict[str, bytes] = {}
+
+    def bucket_exists(self, bucket: str) -> bool:
+        return True
+
+    def make_bucket(self, bucket: str) -> None:  # pragma: no cover - never called
+        pass
+
+    def put_object(self, bucket: str, key: str, data, *, length: int, part_size: int):
+        self.objects[key] = data.read()
+
+    def get_object(self, bucket: str, key: str) -> _DummyObject:
+        return _DummyObject(self.objects[key])
+
+
+@pytest.mark.example
+def test_usage_example_executes(monkeypatch, capsys):
+    """Run the README usage example with a stubbed MinIO client."""
+
+    readme_path = Path(__file__).resolve().parent.parent / "README.md"
+    content = readme_path.read_text(encoding="utf-8")
+    match = re.search(r"```python\n(.*?)```", content, re.DOTALL)
+    assert match, "Could not find a python code block in the README"
+    code = match.group(1)
+    assert "MinioStorageAdapter" in code, "Unexpected python example selected"
+
+    import swarmauri_storage_minio.minio_storage_adapter as adapter_module
+
+    monkeypatch.setattr(adapter_module, "Minio", _DummyClient)
+
+    namespace: dict[str, object] = {}
+    exec(compile(code, str(readme_path), "exec"), namespace)
+
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured, "The example did not produce any output"
+    assert len(captured) >= 2, f"Unexpected output: {captured!r}"
+    assert captured[0].endswith("artifact.txt"), captured[0]
+    assert captured[1] == "data", captured
+
+    assert namespace["uri"].endswith("artifact.txt")  # type: ignore[index]
+    assert namespace["downloaded"] == b"data"  # type: ignore[index]


### PR DESCRIPTION
## Summary
- refresh the MinIO storage README to document current features and add uv/poetry installation guidance
- expand usage instructions with configuration details that reflect the adapter’s behavior
- add a README-backed pytest and register the `example` marker to ensure the documented example continues to work

## Testing
- uv run --directory pkgs/standards/swarmauri_storage_minio --package swarmauri_storage_minio pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca78444e788331bf000fbd11ac9a31