### PR TITLE
Improve introspection README coverage

### DIFF
--- a/pkgs/standards/swarmauri_tokens_introspection/README.md
+++ b/pkgs/standards/swarmauri_tokens_introspection/README.md
@@ -26,30 +26,90 @@ An OAuth 2.0 token introspection service plugin implementing RFC 7662 for verify
 
 ## Features
 
-- Asynchronous token verification against a remote introspection endpoint
-- Supports `client_secret_basic`, `client_secret_post`, and bearer authentication
-- Caches positive and negative introspection results with configurable TTLs
-- Validates standard claims (`exp`, `nbf`, `iat`) with optional issuer and audience checks
-- Optional JWKS passthrough for issuers that also publish signing keys
+- Asynchronous token verification against a remote introspection endpoint using `httpx`
+- Supports `client_secret_basic`, `client_secret_post`, and bearer authentication schemes
+- Caches positive and negative introspection results with configurable TTLs and expiry-aware caching
+- Validates standard claims (`exp`, `nbf`, `iat`) with optional issuer and audience enforcement
+- Optional JWKS passthrough for issuers that also publish signing keys via `jwks_url`
+- Strictly verification-only: `mint()` raises `NotImplementedError` because opaque tokens are produced by the authorization server
 
 ## Installation
+
+Choose the toolchain that matches your project:
 
 ```bash
 pip install swarmauri_tokens_introspection
 ```
 
+```bash
+poetry add swarmauri_tokens_introspection
+```
+
+```bash
+uv add swarmauri_tokens_introspection
+```
+
+The package exposes an async API, so ensure your environment includes an event loop (e.g., `asyncio`) when calling it.
+
 ## Usage
 
+The example below demonstrates how to exercise the service with a mocked introspection endpoint. The same API works against a live OAuth 2.0 Authorization Server—simply omit the mock transport and let `httpx` reach your configured `endpoint`.
+
 ```python
+"""Execute the README example with `python README_example.py`."""
+
+import asyncio
+
+import httpx
+
 from swarmauri_tokens_introspection import IntrospectionTokenService
 
-service = IntrospectionTokenService(
-    "https://auth.example.com/introspect",
-    client_id="id",
-    client_secret="secret",
-)
-claims = await service.verify("opaque-token")
+
+async def main() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url == httpx.URL("https://auth.example.com/introspect")
+        assert request.headers["Authorization"].startswith("Basic ")
+        form = dict(httpx.QueryParams(request.content.decode()))
+        assert form["token"] == "opaque-token"
+        return httpx.Response(
+            200,
+            json={
+                "active": True,
+                "sub": "user-123",
+                "scope": "profile email",
+                "exp": 2_147_483_647,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    service = IntrospectionTokenService(
+        "https://auth.example.com/introspect",
+        client_id="id",
+        client_secret="secret",
+        cache_ttl_s=300,
+    )
+
+    # Inject the mock transport; in production you would not override the client.
+    service._client = httpx.AsyncClient(transport=transport)
+
+    claims = await service.verify("opaque-token")
+    print(claims["sub"])  # user-123
+
+    await service.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
+
+### Caching and validation highlights
+
+- Positive responses respect both `cache_ttl_s` and the `exp` claim (including the configured leeway).
+- Negative introspection results are cached for `negative_ttl_s` seconds to shield your AS from repeated invalid requests.
+- Local validation enforces `exp`, `nbf`, and `iat` drift using `leeway_s`, and supports issuer/audience pinning.
+- Configuring `jwks_url` enables `jwks()` passthrough for deployments that expose signing keys alongside introspection.
 
 ## License
 

--- a/pkgs/standards/swarmauri_tokens_introspection/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_introspection/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_tokens_introspection/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_tokens_introspection/tests/test_readme_example.py
@@ -1,0 +1,36 @@
+"""README example regression tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def _load_python_example() -> str:
+    in_block = False
+    lines: list[str] = []
+    for line in README_PATH.read_text().splitlines():
+        if not in_block:
+            if line.startswith("```python"):
+                in_block = True
+            continue
+        if line.strip() == "```":
+            break
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
+@pytest.mark.example
+def test_readme_usage_example_executes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code = _load_python_example()
+    assert code, "README python example not found"
+    namespace = {"__name__": "__main__"}
+    exec(compile(code, str(README_PATH), "exec"), namespace)
+    out = capsys.readouterr().out
+    assert "user-123" in out


### PR DESCRIPTION
## Summary
- refresh the README to describe the introspection service behaviour and expand installation guidance
- document a runnable async usage example backed by a mocked introspection endpoint
- add a README-backed pytest and register an `example` marker so documentation stays executable

## Testing
- uv run --directory pkgs/standards/swarmauri_tokens_introspection --package swarmauri_tokens_introspection pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7841c60883318653ee32d61d89d6