### PR TITLE
docs: add README example for logging middleware

### DIFF
--- a/pkgs/standards/swarmauri_middleware_logging/README.md
+++ b/pkgs/standards/swarmauri_middleware_logging/README.md
@@ -22,14 +22,63 @@
 
 # Swarmauri Middleware Logging
 
-Middleware for logging requests and responses in Swarmauri applications.
+HTTP middleware for logging requests and responses in Swarmauri and FastAPI applications.
+
+## Features
+
+- Logs the HTTP method and path for each incoming request.
+- Captures request headers and attempts to parse JSON bodies for inspection.
+- Emits a warning when the request body cannot be decoded as JSON.
+- Measures total processing time and records the response status code.
 
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_middleware_logging
 ```
 
+```bash
+poetry add swarmauri_middleware_logging
+```
+
+```bash
+uv pip install swarmauri_middleware_logging
+```
+
+```bash
+uv add swarmauri_middleware_logging
+```
+
+## Example
+
+```python
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from swarmauri_middleware_logging import LoggingMiddleware
+
+app = FastAPI()
+logging_middleware = LoggingMiddleware()
+
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    return await logging_middleware.dispatch(request, call_next)
+
+
+@app.post("/echo")
+async def echo(payload: dict):
+    return payload
+
+
+client = TestClient(app)
+print(client.post("/echo", json={"message": "hello"}).json())
+```
+
+Running the example prints the echoed payload and produces INFO-level log entries for the request and response lifecycle.
+
 ## Want to help?
 
-If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_logging/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_logging/pyproject.toml
@@ -35,6 +35,7 @@ markers = [
     "unit: Unit tests",
     "i9n: Integration tests",
     "r8n: Regression tests",
+    "example: Documentation and README examples",
     "timeout: mark test to timeout after X seconds",
     "xpass: Expected passes",
     "xfail: Expected failures",

--- a/pkgs/standards/swarmauri_middleware_logging/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_logging/tests/example/test_readme_example.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+EXAMPLE_PATTERN = re.compile(r"## Example.*?```python\n(.*?)```", re.DOTALL)
+
+
+@pytest.mark.example
+def test_readme_example_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+    match = EXAMPLE_PATTERN.search(readme)
+    assert match, "README example code block not found"
+
+    snippet = match.group(1)
+    capsys.readouterr()  # Clear any pre-existing captured output.
+
+    exec(compile(snippet, README_PATH.name, "exec"), {})  # noqa: S102
+
+    captured = capsys.readouterr()
+    output_lines = [line for line in captured.out.splitlines() if line]
+    assert output_lines, "README example produced no output"
+    assert output_lines[-1] == "{'message': 'hello'}"


### PR DESCRIPTION
## Summary
- document the logging middleware’s core behavior and add pip/poetry/uv install guidance
- add a runnable FastAPI example to the README and cover it with a pytest that executes the snippet
- register the `example` pytest marker so documentation tests run without warnings

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_logging --package swarmauri_middleware_logging ruff format .
- uv run --directory pkgs/standards/swarmauri_middleware_logging --package swarmauri_middleware_logging ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_middleware_logging --package swarmauri_middleware_logging pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca7830925c8331a5b25ea80d3db9a2