### PR TITLE
Document exception handling middleware usage

### DIFF
--- a/pkgs/standards/swarmauri_middleware_exceptionhandling/README.md
+++ b/pkgs/standards/swarmauri_middleware_exceptionhandling/README.md
@@ -24,22 +24,72 @@
 
 Centralized exception and error handling for Swarmauri applications built on FastAPI.
 
+## Features
+
+- Wraps unhandled exceptions in a consistent JSON payload with the error type,
+  message, and a UTC timestamp.
+- Logs request metadata (method, path, and headers) alongside the stack trace to
+  simplify troubleshooting.
+- Registers through the Swarmauri component system and can be attached to any
+  FastAPI application via `app.middleware("http")`.
+
 ## Installation
+
+Pick the workflow that matches your project:
 
 ```bash
 pip install swarmauri_middleware_exceptionhandling
 ```
 
+```bash
+poetry add swarmauri_middleware_exceptionhandling
+```
+
+```bash
+uv pip install swarmauri_middleware_exceptionhandling
+# or, inside a uv project
+uv add swarmauri_middleware_exceptionhandling
+```
+
 ## Usage
+
+Attach the middleware to convert uncaught exceptions into the structured error
+response returned by Swarmauri services.
 
 ```python
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 from swarmauri_middleware_exceptionhandling import ExceptionHandlingMiddleware
 
 app = FastAPI()
 app.middleware("http")(ExceptionHandlingMiddleware())
+
+
+@app.get("/boom")
+async def boom():
+    raise RuntimeError("Boom!")
+
+
+client = TestClient(app)
+response = client.get("/boom")
+assert response.status_code == 500
+print(response.json())
+```
+
+The JSON payload produced by the middleware includes the error type, message,
+and a timestamp similar to the following:
+
+```json
+{
+  "error": {
+    "type": "Unhandled Exception",
+    "message": "Boom!",
+    "timestamp": "2024-05-01T12:34:56.789012"
+  }
+}
 ```
 
 ## Want to help?
 
-If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_exceptionhandling/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_exceptionhandling/pyproject.toml
@@ -31,6 +31,7 @@ swarmauri_standard = {workspace = true}
 norecursedirs = ["combined", "scripts"]
 markers = [
     "test: standard test",
+    "example: Example usage tests",
     "unit: Unit tests",
     "i9n: Integration tests",
     "r8n: Regression tests",

--- a/pkgs/standards/swarmauri_middleware_exceptionhandling/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_exceptionhandling/tests/example/test_readme_example.py
@@ -1,0 +1,54 @@
+"""Execute the README usage example to keep documentation accurate."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+README_PATH: Final[Path] = Path(__file__).resolve().parents[2] / "README.md"
+
+
+def _extract_usage_snippet() -> str:
+    """Return the README's primary usage example."""
+    content = README_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(r"```python\n(?P<code>.*?)```", re.DOTALL)
+
+    for match in pattern.finditer(content):
+        code = match.group("code").strip()
+        if "ExceptionHandlingMiddleware" in code and "TestClient" in code:
+            return code
+
+    raise AssertionError("README usage example not found")
+
+
+@pytest.mark.example
+@pytest.mark.test
+def test_readme_usage_example() -> None:
+    """Execute the README usage snippet and validate the response payload."""
+
+    namespace: dict[str, object] = {}
+    exec(_extract_usage_snippet(), namespace)
+
+    response = namespace.get("response")
+    assert response is not None, "README example must assign a `response` variable."
+
+    status_code = getattr(response, "status_code", None)
+    assert status_code == 500, (
+        "README example should demonstrate the 500 error response."
+    )
+
+    json_method = getattr(response, "json", None)
+    assert callable(json_method), (
+        "README example response must provide a .json() accessor."
+    )
+
+    payload = json_method()
+    assert isinstance(payload, dict)
+    assert payload.get("error", {}).get("type") == "Unhandled Exception"
+    assert payload.get("error", {}).get("message") == "Boom!"
+    assert "timestamp" in payload.get("error", {})


### PR DESCRIPTION
## Summary
- document middleware behavior with feature overview plus pip, Poetry, and uv installation commands
- add a README usage example that demonstrates the JSON error payload returned by the middleware
- execute the README example in a pytest marked as `example` and register the new mark for the package

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_exceptionhandling --package swarmauri_middleware_exceptionhandling pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7817ecfc8331b25958f3ace76b6e