### PR TITLE
Document JSON-RPC middleware usage and test README example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_jsonrpc/README.md
+++ b/pkgs/standards/swarmauri_middleware_jsonrpc/README.md
@@ -24,6 +24,35 @@
 
 Middleware that performs simple validation of JSON-RPC requests.
 
+## Features
+
+- Validates JSON request bodies for JSON-RPC payloads when the
+  `Content-Type` header starts with `application/json`.
+- Returns `400 Bad Request` with a plain-text error when the body contains
+  invalid JSON.
+- Ensures JSON object payloads define a `jsonrpc` field, responding with
+  `400 Bad Request` if it is missing.
+
+## Installation
+
+Install the middleware with your preferred Python packaging workflow:
+
+```bash
+pip install swarmauri_middleware_jsonrpc
+```
+
+```bash
+poetry add swarmauri_middleware_jsonrpc
+```
+
+```bash
+uv add swarmauri_middleware_jsonrpc
+```
+
+```bash
+uv pip install swarmauri_middleware_jsonrpc
+```
+
 ## Usage
 
 ```python
@@ -33,3 +62,16 @@ from swarmauri_middleware_jsonrpc import JsonRpcMiddleware
 app = FastAPI()
 app.middleware("http")(JsonRpcMiddleware().dispatch)
 ```
+
+The middleware integrates with FastAPI's `app.middleware("http")` hook and is
+compatible with the `MiddlewareBase` ecosystem.  Once registered, every incoming
+JSON request is validated before reaching subsequent middleware or route
+handlers.
+
+## Request Validation
+
+- Requests without an `application/json` content type bypass the middleware.
+- Malformed JSON bodies are rejected with a `400` response containing the
+  message `Invalid JSON`.
+- JSON objects missing the `jsonrpc` key are rejected with a `400` response and
+  the message `Missing jsonrpc field`.

--- a/pkgs/standards/swarmauri_middleware_jsonrpc/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_jsonrpc/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_jsonrpc/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_jsonrpc/tests/test_readme_example.py
@@ -1,0 +1,53 @@
+"""Tests that the README usage example continues to function."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.example
+def test_readme_usage_example() -> None:
+    """Execute the README example and verify middleware behaviour."""
+
+    readme_path = Path(__file__).resolve().parent.parent / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+    code_blocks = re.findall(r"```python\n(.*?)```", readme_text, re.DOTALL)
+    assert code_blocks, "Expected at least one Python example in README.md"
+
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(compile(code_blocks[0], str(readme_path), "exec"), namespace)
+
+    app = namespace.get("app")
+    assert isinstance(app, FastAPI), "README example must define a FastAPI app"
+
+    @app.post("/echo")
+    async def echo(
+        payload: dict[str, object],
+    ) -> dict[str, object]:  # pragma: no cover - exercised via TestClient
+        return {"payload": payload}
+
+    client = TestClient(app)
+
+    missing_jsonrpc = client.post("/echo", json={"method": "ping"})
+    assert missing_jsonrpc.status_code == 400
+    assert "jsonrpc" in missing_jsonrpc.text
+
+    invalid_json = client.post(
+        "/echo",
+        data="not json",
+        headers={"content-type": "application/json"},
+    )
+    assert invalid_json.status_code == 400
+    assert "Invalid JSON" in invalid_json.text
+
+    valid_jsonrpc = client.post(
+        "/echo",
+        json={"jsonrpc": "2.0", "method": "ping"},
+    )
+    assert valid_jsonrpc.status_code == 200
+    assert valid_jsonrpc.json() == {"payload": {"jsonrpc": "2.0", "method": "ping"}}


### PR DESCRIPTION
## Summary
- expand the JSON-RPC middleware README with validation details and installation instructions for pip, Poetry, and uv
- document the middleware’s request handling behaviour to align the README with the implementation
- add an example-marked pytest that executes the README usage snippet and registers the marker in pytest configuration

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_jsonrpc --package swarmauri_middleware_jsonrpc pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7813670083319562e5a255d73a8d