### PR TITLE
Document middleware behavior and test README example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_llamaguard/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_llamaguard/pyproject.toml
@@ -41,6 +41,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_llamaguard/tests/conftest.py
+++ b/pkgs/standards/swarmauri_middleware_llamaguard/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Test configuration for swarmauri_middleware_llamaguard."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def clear_groq_api_key() -> Iterator[None]:
+    """Ensure tests run without a real Groq API key."""
+
+    original = os.environ.pop("GROQ_API_KEY", None)
+    try:
+        yield
+    finally:
+        if original is not None:
+            os.environ["GROQ_API_KEY"] = original

--- a/pkgs/standards/swarmauri_middleware_llamaguard/tests/test_readme_examples.py
+++ b/pkgs/standards/swarmauri_middleware_llamaguard/tests/test_readme_examples.py
@@ -1,0 +1,32 @@
+"""README example tests for swarmauri_middleware_llamaguard."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def _extract_basic_request_filtering_example() -> str:
+    """Return the README example code block for basic request filtering."""
+
+    content = README_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r"```python\n# README Example: Basic request filtering\n(?P<code>.*?)```",
+        re.DOTALL,
+    )
+    match = pattern.search(content)
+    assert match, "README example code block not found."
+    return match.group("code")
+
+
+@pytest.mark.example
+def test_readme_basic_request_filtering_example_executes() -> None:
+    """Execute the README's basic request filtering example."""
+
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(_extract_basic_request_filtering_example(), namespace)


### PR DESCRIPTION
## Summary
- document the middleware's Groq-backed behaviour, expanded installation guidance, and updated usage examples in the README
- add a pytest `example` marker, a README-backed example test, and a session fixture that removes any accidental Groq API key for repeatable runs

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_llamaguard --package swarmauri_middleware_llamaguard pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca782f9b5083319bac4e3328be7222