### PR TITLE
Align RateLimit middleware docs with runtime behavior

### DIFF
--- a/pkgs/standards/swarmauri_middleware_ratelimit/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_ratelimit/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_ratelimit/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_ratelimit/tests/example/test_readme_example.py
@@ -1,0 +1,37 @@
+"""Executable version of the README usage example."""
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.responses import Response
+
+from swarmauri_middleware_ratelimit import RateLimitMiddleware
+
+
+@pytest.mark.example
+def test_readme_rate_limit_example() -> None:
+    """Verify the README example matches the actual middleware behavior."""
+
+    app = FastAPI()
+    rate_limiter = RateLimitMiddleware(rate_limit=2, time_window=60)
+
+    @app.middleware("http")
+    async def limit_requests(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        return await rate_limiter.dispatch(request, call_next)
+
+    @app.get("/ping")
+    async def ping() -> dict[str, str]:
+        return {"status": "ok"}
+
+    client = TestClient(app)
+
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 200
+
+    response = client.get("/ping")
+    assert response.status_code == 429
+    assert response.text == "Rate limit exceeded"


### PR DESCRIPTION
## Summary
- describe the in-memory rate limiting flow accurately and document Poetry/uv installation alongside pip instructions
- update README usage examples to match the middleware’s runtime API and highlight token header error handling
- add a README-backed pytest example and register the `example` marker for the package

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_ratelimit --package swarmauri_middleware_ratelimit ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_middleware_ratelimit --package swarmauri_middleware_ratelimit pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7830f9708331bfaa0c8bc80d4087