### PR TITLE
Update CORS middleware README with runnable example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_cors/README.md
+++ b/pkgs/standards/swarmauri_middleware_cors/README.md
@@ -22,14 +22,89 @@
 
 # Swarmauri Middleware CORS
 
-Custom CORS Middleware for Swarmauri Framework
+Custom CORS middleware for the Swarmauri framework that integrates with FastAPI applications.
+
+## Features
+
+- Handles CORS preflight (`OPTIONS`) requests directly and returns a `200` response with your configured headers.
+- Adds CORS headers to downstream responses produced by your FastAPI routes.
+- Rejects requests with a missing `Origin` header or an origin that is not explicitly allowed, returning a `403` response.
+- Allows fine-grained control of the exposed headers, allowed methods, credentials support, and cache duration of the CORS policy.
 
 ## Installation
+
+### pip
 
 ```bash
 pip install swarmauri_middleware_cors
 ```
 
+### Poetry
+
+```bash
+poetry add swarmauri_middleware_cors
+```
+
+### uv
+
+```bash
+uv venv
+source .venv/bin/activate  # Use .\.venv\Scripts\activate on Windows
+uv add swarmauri_middleware_cors
+```
+
+## Usage
+
+Configure the middleware with the exact origins, methods, and headers you want to allow. Origins are matched literally—if you use the default `['*']` setting, every request must send an `Origin: *` header. In practice you should list the concrete origins your frontend sends.
+
+### Python example
+
+```python
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from swarmauri_middleware_cors import CustomCORSMiddleware
+
+app = FastAPI()
+
+cors = CustomCORSMiddleware(
+    allow_origins=["https://frontend.example"],
+    allow_methods=["GET", "OPTIONS"],
+    allow_headers=["Authorization"],
+    expose_headers=["X-App-Version"],
+    max_age=300,
+)
+
+
+@app.middleware("http")
+async def apply_custom_cors(request, call_next):
+    return await cors.dispatch(request, call_next)
+
+
+@app.get("/ping")
+async def ping():
+    return {"status": "ok"}
+
+
+client = TestClient(app)
+
+if __name__ == "__main__":
+    options_response = client.options(
+        "/ping", headers={"Origin": "https://frontend.example"}
+    )
+    print(
+        "Allowed origin header:",
+        options_response.headers["Access-Control-Allow-Origin"],
+    )
+
+    response = client.get(
+        "/ping", headers={"Origin": "https://frontend.example"}
+    )
+    print("Response JSON:", response.json())
+```
+
+Running the example prints the allowed origin configured on the middleware and the JSON payload returned by the `GET /ping` route.
+
 ## Want to help?
 
-If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_cors/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_cors/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example tests that execute documentation snippets",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_cors/tests/examples/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_cors/tests/examples/test_readme_example.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_python_example_runs(capsys):
+    """Ensure the Python example in the README executes without errors."""
+
+    readme_path = Path(__file__).resolve().parents[2] / "README.md"
+    readme_content = readme_path.read_text(encoding="utf-8")
+
+    code_block = re.search(r"```python\n(.*?)\n```", readme_content, re.DOTALL)
+    assert code_block, "Python example not found in README.md"
+
+    code = code_block.group(1)
+
+    exec_globals: dict[str, object] = {"__name__": "__main__"}
+    exec(compile(code, str(readme_path), "exec"), exec_globals)
+
+    captured = capsys.readouterr()
+    assert "Allowed origin header: https://frontend.example" in captured.out
+    assert "Response JSON: {'status': 'ok'}" in captured.out


### PR DESCRIPTION
## Summary
- document the CORS middleware behaviour and add pip, Poetry, and uv installation guidance alongside a runnable FastAPI example
- add a pytest that executes the README Python example to keep the documentation in sync with the package
- register a dedicated `example` pytest marker for the new documentation test

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_cors --package swarmauri_middleware_cors ruff format .
- uv run --directory pkgs/standards/swarmauri_middleware_cors --package swarmauri_middleware_cors ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_middleware_cors --package swarmauri_middleware_cors pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7818ba9483319e85f0c9ad579a22