### PR TITLE
Update gzip middleware documentation and example test

### DIFF
--- a/pkgs/standards/swarmauri_middleware_gzipcompression/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_gzipcompression/pyproject.toml
@@ -42,6 +42,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_gzipcompression/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_gzipcompression/tests/test_readme_example.py
@@ -1,0 +1,27 @@
+"""Tests that ensure the README example stays runnable."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_example_executes() -> None:
+    """Execute the Python example from the README to keep it in sync."""
+    readme_path = Path(__file__).resolve().parents[1] / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    match = re.search(r"```python\s*(.*?)```", readme_text, re.DOTALL)
+    assert match, "No python example found in README.md"
+
+    example_code = match.group(1)
+    namespace: dict[str, object] = {}
+    exec(compile(example_code, str(readme_path), "exec"), namespace)
+
+    run_example = namespace.get("run_example")
+    assert callable(run_example), "README example must define run_example()"
+
+    run_example()


### PR DESCRIPTION
## Summary
- document pip, Poetry, and uv installation commands for the gzip middleware and describe when compression is applied
- add a runnable asyncio-based README example that demonstrates gzip compression
- introduce a pytest marked as example that executes the README snippet and register the marker in pytest configuration

## Testing
- `uv run --directory pkgs/standards/swarmauri_middleware_gzipcompression --package swarmauri_middleware_gzipcompression ruff format .`
- `uv run --directory pkgs/standards/swarmauri_middleware_gzipcompression --package swarmauri_middleware_gzipcompression ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_middleware_gzipcompression --package swarmauri_middleware_gzipcompression pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ca78150e54833195449229b477c962