### PR TITLE
Update ECDH-ES KW README and add example test

### DIFF
--- a/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/README.md
@@ -19,32 +19,77 @@
 
 ECDH-ES+A128KW based multi-recipient encryption provider implementing the `IMreCrypto` contract.
 
-- ECDH-ES key agreement per recipient
-- AES-128 Key Wrap of a shared content-encryption key
-- AES-128-GCM payload encryption with optional AAD
+### Capabilities
+
+- Per-recipient ECDH-ES key agreement over `secp256r1`
+- AES-128 Key Wrap (KW) of the derived content-encryption key
+- AES-128-GCM payload encryption with optional additional authenticated data (AAD)
+- Supported payload algorithm: `A128GCM`
+- Supported recipient algorithm: `ECDH-ES+A128KW`
+- Supported MRE mode: `MreMode.ENC_ONCE_HEADERS`
+- Re-wrapping existing envelopes is not supported
 
 ### Installation
+
+#### pip
 
 ```bash
 pip install swarmauri_mre_crypto_ecdh_es_kw
 ```
 
-### Usage
+#### Poetry
 
-```python
-from cryptography.hazmat.primitives.asymmetric import ec
-from swarmauri_mre_crypto_ecdh_es_kw import EcdhEsA128KwMreCrypto
-
-crypto = EcdhEsA128KwMreCrypto()
-
-sk = ec.generate_private_key(ec.SECP256R1())
-pk = sk.public_key()
-ref = {"kid": "1", "version": 1, "kind": "cryptography_obj", "obj": pk}
-
-env = await crypto.encrypt_for_many([ref], b"secret")
-pt = await crypto.open_for({"kind": "cryptography_obj", "obj": sk}, env)
+```bash
+poetry add swarmauri_mre_crypto_ecdh_es_kw
 ```
 
-## Entry point
+#### uv
 
-The provider is registered under the `swarmauri.mre_cryptos` entry-point as `EcdhEsA128KwMreCrypto`.
+1. Install [`uv`](https://docs.astral.sh/uv/) if it is not already available:
+
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+2. Add the package to your environment:
+
+   ```bash
+   uv pip install swarmauri_mre_crypto_ecdh_es_kw
+   ```
+
+### Usage
+
+The provider operates asynchronously. The example below demonstrates encrypting and decrypting a payload for a single
+recipient whose key is provided as a `cryptography` object reference. The same `aad` (if provided) must be used for
+both encryption and decryption.
+
+```python
+import asyncio
+
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from swarmauri_mre_crypto_ecdh_es_kw import EcdhEsA128KwMreCrypto
+
+
+async def main() -> None:
+    crypto = EcdhEsA128KwMreCrypto()
+
+    sk = ec.generate_private_key(ec.SECP256R1())
+    pk = sk.public_key()
+    recipient = {"kid": "1", "version": 1, "kind": "cryptography_obj", "obj": pk}
+
+    envelope = await crypto.encrypt_for_many([recipient], b"secret", aad=b"metadata")
+    plaintext = await crypto.open_for(
+        {"kind": "cryptography_obj", "obj": sk}, envelope, aad=b"metadata"
+    )
+
+    assert plaintext == b"secret"
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### Entry point
+
+The provider is registered under the `swarmauri.mre_cryptos` entry point as `EcdhEsA128KwMreCrypto`.

--- a/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/tests/unit/test_readme_example.py
+++ b/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/tests/unit/test_readme_example.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+CODE_SNIPPET_PATTERN = re.compile(r"```python\n(?P<code>.*?)\n```", re.DOTALL)
+
+
+@pytest.mark.example
+def test_readme_example_executes() -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+    match = CODE_SNIPPET_PATTERN.search(readme)
+    assert match, "README is missing a Python usage example"
+
+    code = match.group("code")
+    namespace: dict[str, object] = {
+        "__name__": "__main__",
+        "__builtins__": __builtins__,
+    }
+    exec(compile(code, str(README_PATH), "exec"), namespace)


### PR DESCRIPTION
## Summary
- align the ECDH-ES+A128KW README with the provider's capabilities and expand installation guidance
- document an asyncio usage example and ensure it matches package behaviour
- add a README-backed pytest marked as an example and register the pytest marker

## Testing
- uv run --directory pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw --package swarmauri_mre_crypto_ecdh_es_kw pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7809a8508331a3a242db8fe39c51