### PR TITLE
Document TimerMiddleware usage and test README example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_time/README.md
+++ b/pkgs/standards/swarmauri_middleware_time/README.md
@@ -22,12 +22,77 @@
 
 # Swarmauri Middleware Time
 
-Middleware for tracking request processing time in Swarmauri applications
+Middleware for tracking request processing time in Swarmauri applications.
+
+## Features
+
+- Logs when each request starts and when it completes using Python's `logging` module.
+- Measures the total time spent handling a request and attaches `X-Request-Duration`
+  and `X-Request-Start-Time` headers to the response.
+- Raises an `HTTPException` with status code `500` if an unexpected error occurs
+  while the downstream handler is executing.
 
 ## Installation
 
+### pip
+
 ```bash
 pip install swarmauri_middleware_time
+```
+
+### Poetry
+
+```bash
+poetry add swarmauri_middleware_time
+```
+
+### uv
+
+```bash
+# Install uv if it is not already available
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Add the middleware to your project
+uv add swarmauri_middleware_time
+```
+
+## Usage
+
+The middleware exposes a standard `dispatch` method that matches FastAPI's middleware
+interface. Instantiate it once and forward requests through `dispatch` inside an
+`@app.middleware("http")` hook:
+
+```python
+from fastapi import FastAPI, Request
+from starlette.testclient import TestClient
+
+from swarmauri_middleware_time import TimerMiddleware
+
+app = FastAPI()
+timer_middleware = TimerMiddleware()
+
+
+@app.middleware("http")
+async def add_timer(request: Request, call_next):
+    return await timer_middleware.dispatch(request, call_next)
+
+
+@app.get("/ping")
+async def ping():
+    return {"message": "pong"}
+
+
+if __name__ == "__main__":
+    client = TestClient(app)
+    response = client.get("/ping")
+
+    assert response.json() == {"message": "pong"}
+    assert "X-Request-Duration" in response.headers
+    assert float(response.headers["X-Request-Duration"]) >= 0.0
+    assert "X-Request-Start-Time" in response.headers
+
+    print("Duration header:", response.headers["X-Request-Duration"])
+    print("Start time header:", response.headers["X-Request-Start-Time"])
 ```
 
 ## Want to help?

--- a/pkgs/standards/swarmauri_middleware_time/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_time/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_time/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_time/tests/test_readme_example.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import re
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_example_runs():
+    """Execute the README example to ensure it stays up to date."""
+
+    readme_path = Path(__file__).resolve().parent.parent / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    code_blocks = re.findall(r"```python\n(.*?)\n```", readme_text, re.DOTALL)
+    example_block = next(
+        (block for block in code_blocks if "TimerMiddleware" in block),
+        None,
+    )
+
+    assert example_block is not None, (
+        "Unable to find README example for TimerMiddleware"
+    )
+
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(example_block, namespace)
+
+    response = namespace.get("response")
+    assert response is not None, "README example did not define a response"
+    assert "X-Request-Duration" in response.headers
+    assert float(response.headers["X-Request-Duration"]) >= 0.0
+    assert "X-Request-Start-Time" in response.headers


### PR DESCRIPTION
## Summary
- expand the TimerMiddleware README with feature notes and pip, Poetry, and uv installation instructions
- add a FastAPI usage example demonstrating the middleware and verifying the timing headers
- cover the README example with an `@pytest.mark.example` test and register the marker in pytest configuration

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_time --package swarmauri_middleware_time pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7808d6ac8331929cba4843ac6632