### PR TITLE
docs: update x509verify README example

### DIFF
--- a/pkgs/standards/swarmauri_certs_x509verify/README.md
+++ b/pkgs/standards/swarmauri_certs_x509verify/README.md
@@ -18,28 +18,111 @@
 
 # Swarmauri Certs X509 Verify
 
-A verification-only service for X.509 certificates implementing
-`CertServiceBase`.
+An asynchronous X.509 certificate verification and parsing service
+implementing `CertServiceBase` for the Swarmauri ecosystem. The
+`X509VerifyService` works with PEM or DER encoded certificates to surface
+metadata and perform lightweight trust checks suitable for development
+and integration testing.
 
-Features:
-- Parse certificates for subject, issuer, SAN, EKU and validity times.
-- Basic chain validation and time checks.
+## Features
+
+- Async-first interface exposing `verify_cert` and `parse_cert` coroutines.
+- Accepts PEM or DER encoded certificates without additional tooling.
+- `parse_cert` extracts the serial number, issuer, subject, validity
+  window, signature algorithm, Subject Alternative Names (SAN) and
+  Extended Key Usage (EKU) values.
+- `verify_cert` performs a timestamp check and one-hop signature
+  validation against provided trust roots or intermediates.
+- Designed for basic validation flows – revocation checking and complex
+  path building are intentionally out of scope and reported as
+  `revocation_checked=False` in the response.
 
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_certs_x509verify
 ```
 
-## Usage
+```bash
+poetry add swarmauri_certs_x509verify
+```
+
+```bash
+uv pip install swarmauri_certs_x509verify
+```
+
+## Quick start
+
+The example below issues an in-memory self-signed certificate, parses its
+metadata and verifies the certificate against itself as a trust root.
+Both coroutines are executed with `asyncio.run` for convenience in
+scripts and documentation. The resulting dictionary mirrors the values
+returned by the service at runtime.
 
 ```python
+# README example: verify and parse a development certificate
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
 from swarmauri_certs_x509verify import X509VerifyService
 
-service = X509VerifyService()
+
+def issue_dev_certificate() -> bytes:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "example.test")])
+    now = datetime.now(timezone.utc)
+
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("example.test")]),
+            critical=False,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+            critical=False,
+        )
+        .sign(private_key=private_key, algorithm=hashes.SHA256())
+    )
+
+    return certificate.public_bytes(serialization.Encoding.PEM)
+
+
+async def main() -> dict[str, dict[str, Any]]:
+    certificate_pem = issue_dev_certificate()
+    service = X509VerifyService()
+
+    parsed = await service.parse_cert(certificate_pem)
+    verification = await service.verify_cert(certificate_pem, trust_roots=[certificate_pem])
+
+    return {"parsed": parsed, "verification": verification}
+
+
+example_result = asyncio.run(main())
+print(example_result["parsed"]["subject"])
+print(example_result["verification"]["valid"])
 ```
+
+`example_result["verification"]["valid"]` resolves to `True` when the
+certificate is valid for the supplied timestamp. If the time window fails
+or no matching trust root is provided, the service returns
+`valid=False` and the `reason` field is set to `"invalid_chain_or_time"`.
 
 ## Entry Point
 
 The service registers under the `swarmauri.certs` entry point as
-`X509VerifyService`.
+`X509VerifyService` and under `peagen.plugins.certs` as `x509verify`.

--- a/pkgs/standards/swarmauri_certs_x509verify/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_x509verify/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_certs_x509verify/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_certs_x509verify/tests/example/test_readme_example.py
@@ -1,0 +1,48 @@
+"""Execute the README quick start example to guard against drift."""
+
+from __future__ import annotations
+
+import io
+import re
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+
+@pytest.mark.example
+def test_readme_quick_start_example() -> None:
+    """Run the documented example and validate the observable results."""
+
+    readme_path = Path(__file__).resolve().parents[2] / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    code_blocks = re.findall(r"```python\n(.*?)```", readme_text, flags=re.DOTALL)
+    sentinel = "# README example: verify and parse a development certificate"
+
+    snippet = next((block for block in code_blocks if sentinel in block), None)
+    assert snippet is not None, "README quick start example not found"
+
+    namespace: Dict[str, Any] = {"__builtins__": __builtins__}
+    buffer = io.StringIO()
+
+    with redirect_stdout(buffer):
+        exec(compile(snippet, str(readme_path), "exec"), namespace)
+
+    output = buffer.getvalue()
+    assert "CN=example.test" in output
+    assert "True" in output.splitlines()[-1]
+
+    example_result = namespace.get("example_result")
+    assert isinstance(example_result, dict), (
+        "README example did not expose example_result"
+    )
+
+    parsed = example_result["parsed"]
+    verification = example_result["verification"]
+
+    assert parsed["subject"] == "CN=example.test"
+    assert verification["valid"] is True
+    assert verification["reason"] is None
+    assert verification["revocation_checked"] is False


### PR DESCRIPTION
## Summary
- align the swarmauri_certs_x509verify README with the service capabilities and document pip, poetry, and uv installation commands
- add a runnable quick start example that issues and verifies a development certificate
- back the README example with a pytest marked as `example` and register the marker for the package

## Testing
- uv run --directory pkgs/standards/swarmauri_certs_x509verify --package swarmauri_certs_x509verify pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca775c2360833190cbc4c1e084324c