### PR TITLE
docs: document JWT middleware usage and example test

### DIFF
--- a/pkgs/standards/swarmauri_middleware_jwt/README.md
+++ b/pkgs/standards/swarmauri_middleware_jwt/README.md
@@ -22,11 +22,75 @@
 
 # Swarmauri Middleware JWT
 
-Middleware for validating JWT tokens in Swarmauri applications.
+`JWTMiddleware` validates JSON Web Tokens (JWT) issued to FastAPI-based
+Swarmauri services. The middleware expects a ``Bearer`` token in the
+``Authorization`` header, decodes it with the configured secret and algorithm,
+and stores the decoded payload on ``request.state.jwt_payload``. Requests with
+missing or invalid tokens receive an HTTP 401 response.
 
 ## Installation
 
+### pip
+
 ```bash
 pip install swarmauri_middleware_jwt
+```
+
+### Poetry
+
+```bash
+poetry add swarmauri_middleware_jwt
+```
+
+### uv
+
+```bash
+# Install uv (see https://docs.astral.sh/uv/) if it is not already available
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Use uv to add the middleware to your environment
+uv pip install swarmauri_middleware_jwt
+```
+
+## Example
+
+The example below attaches ``JWTMiddleware`` to a FastAPI application, issues a
+token using ``PyJWT``, and performs a request that reads the decoded payload
+from ``request.state``.
+
+```python
+from fastapi import FastAPI, Request
+from starlette.testclient import TestClient
+import jwt
+
+from swarmauri_middleware_jwt import JWTMiddleware
+
+
+SECRET_KEY = "change-me"
+
+app = FastAPI()
+
+# Register the middleware with the FastAPI app
+jwt_middleware = JWTMiddleware(secret_key=SECRET_KEY)
+app.middleware("http")(jwt_middleware.dispatch)
+
+
+@app.get("/protected")
+async def protected_route(request: Request):
+    return {"subject": request.state.jwt_payload["sub"]}
+
+
+def run_example() -> dict:
+    token = jwt.encode({"sub": "demo-user"}, SECRET_KEY, algorithm="HS256")
+    client = TestClient(app)
+    response = client.get(
+        "/protected", headers={"Authorization": f"Bearer {token}"}
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+if __name__ == "__main__":
+    print(run_example())
 ```
 

--- a/pkgs/standards/swarmauri_middleware_jwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_jwt/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_jwt/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_jwt/tests/test_readme_example.py
@@ -1,0 +1,48 @@
+"""Tests for the README example."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Dict
+
+import pytest
+
+
+README_PATH = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+
+
+def _extract_first_python_block() -> str:
+    """Return the first Python code block from the README."""
+    contents = README_PATH.read_text(encoding="utf-8")
+    lines = []
+    in_block = False
+
+    for raw_line in contents.splitlines():
+        stripped = raw_line.strip()
+        if not in_block and stripped.startswith("```python"):
+            in_block = True
+            continue
+        if in_block and stripped.startswith("```"):
+            break
+        if in_block:
+            lines.append(raw_line)
+
+    if not lines:
+        raise AssertionError("README is missing a Python example block")
+
+    return "\n".join(lines)
+
+
+@pytest.mark.example
+def test_readme_example_runs(capsys):
+    """Execute the README example to ensure it stays up-to-date."""
+    code = _extract_first_python_block()
+    namespace: Dict[str, object] = {"__name__": "__main__"}
+    exec(compile(code, str(README_PATH), "exec"), namespace)  # noqa: S102
+
+    captured = capsys.readouterr()
+    assert "demo-user" in captured.out
+
+    run_example = namespace.get("run_example")
+    assert callable(run_example), "README example must define run_example()"
+    assert run_example() == {"subject": "demo-user"}


### PR DESCRIPTION
## Summary
- describe how JWTMiddleware processes bearer tokens and expand installation guidance, including Poetry, uv, and a runnable FastAPI example
- register the new example pytest marker for the package
- add a README-backed pytest that executes the documentation example to keep it working

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_jwt --package swarmauri_middleware_jwt pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca7804e0488331bb3a4d470b86ecd6