### PR TITLE
Document bulkhead middleware quickstart example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_bulkhead/README.md
+++ b/pkgs/standards/swarmauri_middleware_bulkhead/README.md
@@ -26,19 +26,74 @@ Concurrency isolation middleware for FastAPI applications. Limit the number of s
 
 ## Features
 
-- **Concurrency control** to restrict the maximum number of in-flight requests
-- **Semaphore-based management** for efficient request queuing and processing
-- **Logging integration** to provide visibility into request flow and errors
-- **Configurable limits** to match your service capacity
-- **FastAPI compatibility** for seamless integration
+- **Concurrency control** restricts the number of in-flight requests using an `asyncio.Semaphore`.
+- **Configurable limits** let you tune `max_concurrency` (default: 10) to match service capacity.
+- **Fail-fast validation** guards against non-positive concurrency limits at initialization.
+- **Structured logging** surfaces request flow and failure details for easier diagnostics.
+- **FastAPI compatibility** enables seamless integration into ASGI middleware stacks.
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_middleware_bulkhead
+
+# Poetry
+poetry add swarmauri_middleware_bulkhead
+
+# uv
+uv add swarmauri_middleware_bulkhead
 ```
 
-## Want to help?
+## Quickstart
 
-If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md).
+The middleware wraps a `call_next` handler and ensures that no more than `max_concurrency` requests execute at once. Run the example below with `python quickstart.py` to see the concurrency ceiling in action.
+
+```python
+import asyncio
+
+from fastapi import Request
+
+from swarmauri_middleware_bulkhead import BulkheadMiddleware
+
+
+async def main() -> None:
+    bulkhead = BulkheadMiddleware(max_concurrency=2)
+    active_requests = 0
+    peak_active_requests = 0
+    lock = asyncio.Lock()
+
+    async def call_next(request: Request):
+        nonlocal active_requests, peak_active_requests
+        async with lock:
+            active_requests += 1
+            peak_active_requests = max(peak_active_requests, active_requests)
+
+        try:
+            await asyncio.sleep(0.05)
+            return {"path": request.scope.get("path"), "handled": True}
+        finally:
+            async with lock:
+                active_requests -= 1
+
+    async def simulate_request(idx: int):
+        request = Request(scope={"type": "http", "path": f"/task/{idx}"})
+        return await bulkhead.dispatch(request, call_next)
+
+    responses = await asyncio.gather(*(simulate_request(i) for i in range(5)))
+
+    assert peak_active_requests <= bulkhead.max_concurrency
+    print("Peak concurrent requests:", peak_active_requests)
+    print("Responses:", responses)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## For Contributors
+
+If you want to contribute to `swarmauri_middleware_bulkhead`, please read our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) and [style guide](https://github.com/swarmauri/swarmauri-sdk/blob/master/STYLE_GUIDE.md).
 

--- a/pkgs/standards/swarmauri_middleware_bulkhead/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_bulkhead/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_bulkhead/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_bulkhead/tests/example/test_readme_example.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+README_PATH = PACKAGE_ROOT / "README.md"
+
+
+def _extract_quickstart_code(readme: str) -> str:
+    in_quickstart = False
+    in_code_block = False
+    code_lines: list[str] = []
+
+    for line in readme.splitlines():
+        if line.strip() == "## Quickstart":
+            in_quickstart = True
+            continue
+
+        if not in_quickstart:
+            continue
+
+        if line.startswith("```"):
+            if line.startswith("```python") and not in_code_block:
+                in_code_block = True
+                continue
+            if in_code_block:
+                break
+
+        if in_code_block:
+            code_lines.append(line)
+
+    code = "\n".join(code_lines).strip()
+    if not code:
+        raise AssertionError("Quickstart python code block not found in README")
+    return code
+
+
+@pytest.mark.example
+def test_readme_quickstart_example(capsys: pytest.CaptureFixture[str]) -> None:
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    code = _extract_quickstart_code(readme_text)
+
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(compile(code, str(README_PATH), "exec"), namespace)
+
+    captured = capsys.readouterr().out
+    assert "Peak concurrent requests:" in captured
+    assert "Responses:" in captured


### PR DESCRIPTION
## Summary
- expand the bulkhead middleware README with updated feature notes, installation instructions for pip/Poetry/uv, and a runnable quickstart example
- add a pytest that executes the README quickstart snippet so documentation stays accurate
- register a `pytest` marker for example usage tests

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_bulkhead --package swarmauri_middleware_bulkhead pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca77fb533c8331b67394f622916b55