### PR TITLE
Update cachecontrol README example

### DIFF
--- a/pkgs/standards/swarmauri_middleware_cachecontrol/README.md
+++ b/pkgs/standards/swarmauri_middleware_cachecontrol/README.md
@@ -24,12 +24,77 @@
 
 Middleware for managing HTTP cache headers and client-side caching behavior.
 
+## Features
+
+- Configurable `max_age` that controls how long clients may cache responses.
+- Toggle caching on or off at runtime with the `enabled` flag.
+- Adds `Cache-Control`, timestamp-based `ETag`, and `Vary: Accept-Encoding` headers to successful responses.
+- Inspects `If-Modified-Since` and `If-None-Match` request headers to short-circuit unchanged responses with `304 Not Modified`.
+
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_middleware_cachecontrol
 ```
 
+```bash
+poetry add swarmauri_middleware_cachecontrol
+```
+
+```bash
+uv pip install swarmauri_middleware_cachecontrol
+```
+
+## Usage
+
+`CacheControlMiddleware` accepts two primary configuration options:
+
+- `max_age`: Maximum cache lifetime (in seconds) communicated to clients. Defaults to `3600`.
+- `enabled`: When `False`, the middleware skips all cache headers and lets responses pass through untouched. Defaults to `True`.
+
+When enabled, the middleware injects cache headers into outgoing responses and mirrors conditional request headers to return `304 Not Modified` when the client already has fresh content. Integrate it with FastAPI or Starlette by instantiating the middleware once and delegating to its `dispatch` method from an `@app.middleware("http")` handler.
+
+### Example
+
+The snippet below shows how to register the middleware with FastAPI and inspect the generated headers using `TestClient`:
+
+```python
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from swarmauri_middleware_cachecontrol import CacheControlMiddleware
+
+app = FastAPI()
+cache_control = CacheControlMiddleware(max_age=60)
+
+
+@app.middleware("http")
+async def apply_cache_control(request: Request, call_next):
+    return await cache_control.dispatch(request, call_next)
+
+
+@app.get("/status")
+def status() -> dict[str, str]:
+    return {"state": "fresh"}
+
+
+def main() -> None:
+    client = TestClient(app)
+    response = client.get("/status")
+    response.raise_for_status()
+
+    print("Cache-Control:", response.headers["Cache-Control"])
+    print("ETag:", response.headers["ETag"])
+    print("Vary:", response.headers["Vary"])
+    print("Payload:", response.json())
+
+
+if __name__ == "__main__":
+    main()
+```
+
 ## Want to help?
 
-If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_cachecontrol/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_cachecontrol/pyproject.toml
@@ -42,6 +42,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_middleware_cachecontrol/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_cachecontrol/tests/example/test_readme_example.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+
+def _readme_python_example(readme_path: Path) -> str:
+    lines = readme_path.read_text(encoding="utf-8").splitlines()
+    example_lines: list[str] = []
+    capturing = False
+
+    for line in lines:
+        stripped = line.strip()
+        if not capturing and stripped.lower().startswith("```python"):
+            capturing = True
+            continue
+        if capturing and stripped.startswith("```"):
+            break
+        if capturing:
+            example_lines.append(line)
+
+    if not example_lines:
+        raise AssertionError("No python example found in README.md")
+
+    return "\n".join(example_lines)
+
+
+def _find_line(prefix: str, lines: Iterable[str]) -> str:
+    for line in lines:
+        if line.startswith(prefix):
+            return line
+    raise AssertionError(f"Expected line starting with {prefix!r} in example output")
+
+
+@pytest.mark.example
+def test_readme_example_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    readme_path = Path(__file__).resolve().parents[2] / "README.md"
+    code = _readme_python_example(readme_path)
+
+    exec_globals = {"__name__": "__main__"}
+    exec(compile(code, str(readme_path), "exec"), exec_globals)
+
+    output = capsys.readouterr().out.splitlines()
+    normalized = [line.strip() for line in output if line.strip()]
+
+    assert "Cache-Control: max-age=60, public" in normalized
+
+    etag_line = _find_line("ETag:", normalized)
+    assert etag_line.split(":", 1)[1].strip(), "ETag header should not be empty"
+
+    vary_line = _find_line("Vary:", normalized)
+    assert vary_line == "Vary: Accept-Encoding"
+
+    payload_line = _find_line("Payload:", normalized)
+    assert payload_line.endswith("{'state': 'fresh'}")


### PR DESCRIPTION
## Summary
- align the cache control README with the middleware behaviour, including features, installation commands, and a runnable FastAPI example
- add a pytest that executes the README example to ensure the documentation stays valid
- register the `example` pytest marker for the package

## Testing
- uv run --directory pkgs/standards/swarmauri_middleware_cachecontrol --package swarmauri_middleware_cachecontrol ruff format .
- uv run --directory pkgs/standards/swarmauri_middleware_cachecontrol --package swarmauri_middleware_cachecontrol ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_middleware_cachecontrol --package swarmauri_middleware_cachecontrol pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca77f9da388331ae0c7f4d56fd42f6