### PR TITLE
Align mirrored key provider README and add example test

### DIFF
--- a/pkgs/standards/swarmauri_keyproviders_mirrored/README.md
+++ b/pkgs/standards/swarmauri_keyproviders_mirrored/README.md
@@ -18,35 +18,122 @@
 
 # Swarmauri Mirrored Key Provider
 
-A failover key provider that mirrors keys to a secondary provider for redundancy.
-Supports full and public-only replication with optional extras for canonical
-representations.
+An asynchronous failover key provider that keeps a primary provider as the
+system of record while best-effort mirroring material to a secondary provider
+for redundancy.
 
-Features:
-- Mirror new keys to a secondary provider
-- Failover reads when the primary provider is unavailable
-- JWKS union merging as described in RFC 7517
-- Optional extras for JSON and CBOR canonicalization
+## Features
+
+- Write operations (`create`, `import`, `rotate`, `destroy`) execute on the
+  primary provider first and then mirror to the secondary provider when
+  possible.
+- `mirror_mode` governs what is replicated: `public_only` (default) mirrors only
+  public material, `full` attempts to replicate private material when export
+  policy allows, and `none` disables replication while retaining read
+  failover.
+- Read operations (`get_key`, `get_public_jwk`, `jwks`, `list_versions`,
+  `random_bytes`, `hkdf`) favor the primary provider and fail over to the
+  secondary provider when `fail_open_reads` is enabled.
+- JWKS responses merge keys from both providers, preferring primary entries when
+  the same `kid` appears in both sets.
+- Maintains an in-memory mapping of mirrored key identifiers to coordinate
+  destroy operations and failover reads—persist or rebuild this mapping if you
+  need cross-process continuity.
+- Optional extras add canonical JSON (`jsoncanon`) and CBOR (`cbor`) support for
+  consumers that require deterministic encodings.
 
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_keyproviders_mirrored
 ```
 
+```bash
+poetry add swarmauri_keyproviders_mirrored
+```
+
+```bash
+uv pip install swarmauri_keyproviders_mirrored
+```
+
+Enable extras for canonicalization when needed:
+
+```bash
+pip install swarmauri_keyproviders_mirrored[jsoncanon]
+```
+
+```bash
+pip install swarmauri_keyproviders_mirrored[cbor]
+```
+
 ## Usage
 
+The provider mirrors newly created keys to the secondary provider and fails open
+on reads when the primary becomes unavailable.
+
 ```python
+import asyncio
+
 from swarmauri_keyproviders_mirrored import MirroredKeyProvider
 from swarmauri_keyprovider_local import LocalKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy
+from swarmauri_core.crypto.types import KeyUse
 
-primary = LocalKeyProvider()
-secondary = LocalKeyProvider()
-provider = MirroredKeyProvider(primary, secondary)
+
+async def main() -> None:
+    primary = LocalKeyProvider()
+    secondary = LocalKeyProvider()
+    provider = MirroredKeyProvider(
+        primary,
+        secondary,
+        mirror_mode="public_only",
+        fail_open_reads=True,
+    )
+
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+
+    created = await provider.create_key(spec)
+    jwk = await provider.get_public_jwk(created.kid, created.version)
+
+    await primary.destroy_key(created.kid, created.version)
+    mirrored = await provider.get_public_jwk(created.kid, created.version)
+
+    assert mirrored["x"] == jwk["x"]
+    print(f"Failover retrieved Ed25519 key from secondary provider: {mirrored['kid']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
+
+In the example above the primary key is destroyed after mirroring, forcing
+`MirroredKeyProvider` to serve the public key from the secondary provider.
+Although mirrored keys may have different `kid` values, the public material
+remains identical and ready for verification.
+
+## Mirror Modes
+
+- `public_only` *(default)* — Mirrors public key material and JWKS entries when
+  available.
+- `full` — Attempts to mirror private material when export policy permits,
+  falling back to public-only replication otherwise.
+- `none` — Disables replication while still permitting read failover to the
+  secondary provider.
+
+## Failover Semantics
+
+The `fail_open_reads` flag controls whether read operations fall back to the
+secondary provider when the primary raises an exception. Disable it to surface
+primary errors immediately.
 
 ## Entry Point
 
 The provider registers under the `swarmauri.key_providers` entry point as
 `MirroredKeyProvider`.
-

--- a/pkgs/standards/swarmauri_keyproviders_mirrored/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyproviders_mirrored/pyproject.toml
@@ -37,6 +37,7 @@ norecursedirs = ["combined", "scripts"]
 markers = [
     "test: standard test",
     "unit: Unit tests",
+    "example: Example usage tests",
     "i9n: Integration tests",
     "r8n: Regression tests",
     "acceptance: Acceptance tests",

--- a/pkgs/standards/swarmauri_keyproviders_mirrored/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_keyproviders_mirrored/tests/example/test_readme_example.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+
+
+def _extract_usage_snippet() -> str:
+    contents = README_PATH.read_text(encoding="utf-8")
+    try:
+        usage_section = contents.split("## Usage", maxsplit=1)[1]
+    except IndexError as exc:  # pragma: no cover - defensive clarity
+        raise AssertionError("README missing usage section") from exc
+    match = re.search(r"```python\n(.*?)```", usage_section, re.DOTALL)
+    if not match:
+        raise AssertionError("README usage example missing Python snippet")
+    return textwrap.dedent(match.group(1))
+
+
+@pytest.mark.example
+def test_readme_usage_example() -> None:
+    snippet = _extract_usage_snippet()
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(snippet, namespace)


### PR DESCRIPTION
## Summary
- document the MirroredKeyProvider failover behaviour, mirror modes, and installation options in the README, including a runnable usage example
- add a README-backed example test that executes the documented usage snippet to keep documentation and behaviour aligned
- register the `example` pytest marker so the new test runs without warnings

## Testing
- uv run --directory pkgs/standards/swarmauri_keyproviders_mirrored --package swarmauri_keyproviders_mirrored ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_keyproviders_mirrored --package swarmauri_keyproviders_mirrored pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca77f8a38083319af3be5cfc78209f