### PR TITLE
Update swarmauri_gitfilter_minio README and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_gitfilter_minio/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_minio/README.md
@@ -22,26 +22,48 @@
 
 # Swarmauri Git Filter Minio
 
-Git filter using MinIO or S3 compatible storage.
+`swarmauri_gitfilter_minio` packages the `MinioFilter` plugin used by
+[`peagen`](https://pypi.org/project/peagen/) and other Swarmauri tooling to keep
+large Git objects in MinIO (or any S3-compatible) storage instead of the local
+repository. The filter implements both `StorageAdapterBase` and
+`GitFilterBase`, so you can call it directly from Python code or register it as
+a Git clean/smudge filter.
 
-`swarmauri_gitfilter_minio` provides a storage adapter and Git filter that
-stores repository objects in a remote MinIO (or any S3 compatible) service.
-It is commonly used by the [`peagen`](https://pypi.org/project/peagen/) tool to
-offload large files from source control, but it can also be integrated directly
-into applications that need simple object storage.
+### Highlights
+
+- Accepts `minio://` (HTTP) and `minios://` (HTTPS) URIs and automatically
+  ensures the referenced bucket exists.
+- Inherits `GitFilterBase`, giving you `clean` and `smudge` helpers that hash
+  content, upload it to remote storage, and hydrate it back into your working
+  tree on checkout.
+- Provides convenience methods such as `upload_dir`, `iter_prefix`, and
+  `download_prefix` for whole directory trees in addition to single-file
+  transfers.
+- Surfaces a `root_uri` property that reflects the bucket and optional prefix
+  derived from the connection string.
 
 ## Installation
 
+Choose the workflow that matches your project:
+
 ```bash
+# pip
 pip install swarmauri_gitfilter_minio
+
+# Poetry
+poetry add swarmauri_gitfilter_minio
+
+# uv
+uv add swarmauri_gitfilter_minio
 ```
 
 ## Configuration
 
-The filter reads credentials from either a `peagen.toml` configuration file or
-the `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` environment variables. The bucket
-specified in the URI will be created automatically if it does not already
-exist.
+`MinioFilter.from_uri()` consults `peagen.toml` for credentials under
+`[storage.filters.minio]` and falls back to the `MINIO_ACCESS_KEY` and
+`MINIO_SECRET_KEY` environment variables when the configuration is absent. When
+instantiated, the filter lazily creates the bucket identified by the URI and
+stores objects beneath an optional prefix.
 
 ## Usage
 
@@ -61,5 +83,9 @@ buffer = filt.download("docs/README.md")
 data = buffer.read()
 ```
 
-`MinioFilter` also exposes helpers such as `upload_dir` and `download_prefix`
-for working with entire directory trees.
+`MinioFilter` also exposes helpers such as `upload_dir`, `iter_prefix`, and
+`download_prefix` for working with entire directory trees.
+
+## License
+
+Licensed under the [Apache License, Version 2.0](LICENSE).

--- a/pkgs/standards/swarmauri_gitfilter_minio/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_minio/pyproject.toml
@@ -49,6 +49,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_gitfilter_minio/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_gitfilter_minio/tests/example/test_readme_example.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+class _DummyResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:  # pragma: no cover - trivial accessor
+        return self._data
+
+    def close(self) -> None:  # pragma: no cover - interface stub
+        pass
+
+    def release_conn(self) -> None:  # pragma: no cover - interface stub
+        pass
+
+
+class _DummyMinio:
+    def __init__(
+        self, endpoint: str, *, access_key, secret_key, secure
+    ) -> None:  # pragma: no cover - simple init
+        self._endpoint = endpoint
+        self._secure = secure
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._buckets: set[str] = set()
+        self._store: dict[tuple[str, str], bytes] = {}
+
+    def bucket_exists(self, bucket: str) -> bool:
+        return bucket in self._buckets
+
+    def make_bucket(self, bucket: str) -> None:
+        self._buckets.add(bucket)
+
+    def put_object(self, bucket: str, key: str, data, *, length=-1, part_size=0):
+        self._buckets.add(bucket)
+        data.seek(0)
+        self._store[(bucket, key)] = data.read()
+
+    def get_object(self, bucket: str, key: str):
+        return _DummyResponse(self._store[(bucket, key)])
+
+    def list_objects(
+        self, bucket: str, *, prefix: str, recursive: bool = False
+    ):  # pragma: no cover - unused in test
+        for (obj_bucket, obj_key), _ in self._store.items():
+            if obj_bucket != bucket:
+                continue
+            if not obj_key.startswith(prefix):
+                continue
+            yield type("_Obj", (), {"object_name": obj_key})()
+
+
+def _extract_first_python_block(readme: Path) -> str:
+    content = readme.read_text().splitlines()
+    collecting = False
+    lines: list[str] = []
+    for line in content:
+        stripped = line.strip()
+        if not collecting and stripped.startswith("```python"):
+            collecting = True
+            continue
+        if collecting and stripped.startswith("```"):
+            break
+        if collecting:
+            lines.append(line)
+
+    if not lines:
+        raise AssertionError("README example block is missing")
+
+    return dedent("\n".join(lines))
+
+
+@pytest.mark.example
+def test_readme_usage_example(monkeypatch, tmp_path):
+    pkg_root = Path(__file__).resolve().parents[2]
+    readme_path = pkg_root / "README.md"
+    code = _extract_first_python_block(readme_path)
+
+    monkeypatch.setattr(
+        "swarmauri_gitfilter_minio.minio_filter.Minio",
+        _DummyMinio,
+    )
+    monkeypatch.setattr(
+        "swarmauri_gitfilter_minio.minio_filter.load_peagen_toml",
+        lambda: {
+            "storage": {
+                "filters": {
+                    "minio": {
+                        "access_key": "example-access",
+                        "secret_key": "example-secret",
+                    }
+                }
+            }
+        },
+    )
+
+    expected_payload = b"readme contents"
+    target_readme = tmp_path / "README.md"
+    target_readme.write_bytes(expected_payload)
+    monkeypatch.chdir(tmp_path)
+
+    namespace: dict[str, object] = {}
+    exec(compile(code, str(readme_path), "exec"), namespace, namespace)
+
+    assert namespace["data"] == expected_payload
+    assert namespace["uri"] == "minio://localhost:9000/my-bucket/prefix/docs/README.md"


### PR DESCRIPTION
## Summary
- refresh the swarmauri_gitfilter_minio README to describe the MinioFilter capabilities and list pip/Poetry/uv installation commands
- register the pytest ``example`` marker for the package
- add a README-backed pytest that executes the documented usage snippet with a dummy MinIO client

## Testing
- uv run --directory pkgs/standards --package swarmauri_gitfilter_minio ruff format .
- uv run --directory pkgs/standards --package swarmauri_gitfilter_minio ruff check . --fix
- uv run --directory pkgs/standards --package swarmauri_gitfilter_minio pytest swarmauri_gitfilter_minio/tests


------
https://chatgpt.com/codex/tasks/task_b_68ca77f53e9c8331a657b1446e385dab