### PR TITLE
docs: refresh ssh key provider readme

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_ssh/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/README.md
@@ -10,20 +10,34 @@
 
 # Swarmauri SSH Key Provider
 
-Interfaces with local SSH keys to generate and manage signing keys.
+An asynchronous `KeyProviderBase` implementation that keeps SSH key material in
+memory and bridges it to Swarmauri's signing abstractions.
 
 ## Features
 
-- Generate Ed25519, RSA-PSS, and ECDSA P-256 key pairs.
-- Import existing keys from PEM or OpenSSH formats.
-- Rotate keys and track key versions.
-- Export public keys as JWK or JWKS documents.
-- Produce random bytes or derive material via HKDF.
+- Generate new Ed25519, RSA-PSS (SHA-256), or ECDSA P-256 key pairs on demand.
+- Import existing private keys (PEM) or public keys (OpenSSH) while respecting
+  each key's `ExportPolicy`.
+- Rotate keys, enumerate versions, and optionally destroy specific versions or
+  entire key identifiers.
+- Export public keys as RFC 7517-compliant JWKs/JWKS with OpenSSH fingerprints
+  embedded in the `tags` metadata.
+- Produce random bytes and derive keying material using the HKDF construction
+  (RFC 5869).
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_keyprovider_ssh
+
+# Poetry
+poetry add swarmauri_keyprovider_ssh
+
+# uv
+uv add swarmauri_keyprovider_ssh
 ```
 
 ## Usage
@@ -67,6 +81,10 @@ ref = await provider.create_key(spec)
 await provider.rotate_key(ref.kid)
 assert await provider.list_versions(ref.kid) == (1, 2)
 ```
+
+Use `destroy_key()` to remove an entire key identifier or just a single
+version, and `jwks(prefix_kids=...)` when you need to emit a filtered JWKS for
+downstream consumers.
 
 Existing keys can be imported from PEM or OpenSSH data and exposed via JWKS:
 


### PR DESCRIPTION
## Summary
- describe the SSH key provider as an async in-memory KeyProviderBase and call out its actual lifecycle capabilities
- add pip, Poetry, and uv installation snippets for swarmauri_keyprovider_ssh
- mention destroy_key and JWKS filtering helpers alongside the existing usage examples

## Testing
- uv run --directory pkgs/standards/swarmauri_keyprovider_ssh --package swarmauri_keyprovider_ssh ruff format .
- uv run --directory pkgs/standards/swarmauri_keyprovider_ssh --package swarmauri_keyprovider_ssh ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_keyprovider_ssh --package swarmauri_keyprovider_ssh pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca77e0368483318db3791aba647927