### PR TITLE
docs: expand remote jwks provider README

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_remote_jwks/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_remote_jwks/README.md
@@ -20,10 +20,33 @@
 
 Key provider backed by a remote JWKS endpoint with local key management.
 
+## Features
+
+- Accepts either a direct JWKS URL or an OpenID Connect issuer and resolves the
+  discovery document automatically.
+- Caches the remote JWKS in memory with TTL support, conditional requests, and
+  thread-safe refreshes through `refresh(force=True)`.
+- Supports versioned key identifiers such as `kid.version` when discovering
+  remote public keys.
+- Embeds the standard `LocalKeyProvider` so that services can create, rotate,
+  import, and destroy local keys without leaving memory.
+- Exposes convenience helpers like `random_bytes()` and `hkdf()` for local
+  cryptographic operations alongside the remote verification flow.
+
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_keyprovider_remote_jwks
+```
+
+```bash
+poetry add swarmauri_keyprovider_remote_jwks
+```
+
+```bash
+uv pip install swarmauri_keyprovider_remote_jwks
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- document the remote JWKS provider capabilities, including local key support and caching behaviour
- add installation guidance for pip, poetry, and uv so the README matches other standards packages

## Testing
- uv run --directory pkgs/standards/swarmauri_keyprovider_remote_jwks --package swarmauri_keyprovider_remote_jwks ruff format .
- uv run --directory pkgs/standards/swarmauri_keyprovider_remote_jwks --package swarmauri_keyprovider_remote_jwks ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_keyprovider_remote_jwks --package swarmauri_keyprovider_remote_jwks pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca77df14ac8331a1c1edcf4d5cf143