### PR TITLE
docs: align local key provider README with executable example

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_local/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_local/README.md
@@ -10,23 +10,40 @@
 
 # Swarmauri Local Key Provider
 
-Provides a simple in-memory key provider for development and testing.
+Provides a pure in-memory implementation of the `KeyProviderBase` suitable for
+local development, unit testing, and rapid prototyping without any external
+infrastructure.
 
-## Features
+## Capabilities
 
-- Supports AES-256-GCM, Ed25519, X25519, RSA, and ECDSA algorithms.
-- Pure in-memory storage ideal for tests and local development.
-- Import existing keys and rotate through multiple versions.
-- Export public keys as JWK or JWKS documents.
-- Generate random bytes or derive material with HKDF.
+- Generate symmetric AES-256-GCM keys and several asymmetric algorithms
+  (Ed25519, X25519, RSA-OAEP/PSS-SHA256, and ECDSA P-256-SHA256).
+- Import existing key material and rotate to new versions on demand.
+- Retrieve stored keys (optionally including the secret material) and list
+  available versions.
+- Export public material as individual JWKs or aggregate JWKS documents.
+- Produce cryptographically secure random bytes or derive material using HKDF.
+- Destroy keys when they are no longer needed to keep local environments tidy.
 
 ## Installation
 
+Choose the tool that best matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_keyprovider_local
+
+# Poetry
+poetry add swarmauri_keyprovider_local
+
+# uv
+uv add swarmauri_keyprovider_local
 ```
 
-## Usage
+## Quickstart
+
+The example below mirrors `swarmauri_keyprovider_local.examples.basic_usage`
+and demonstrates how to create, store, and retrieve a symmetric key.
 
 ```python
 import asyncio
@@ -41,6 +58,8 @@ from swarmauri_core.crypto.types import KeyUse
 
 
 async def run_example() -> str:
+    """Create and retrieve a symmetric key using LocalKeyProvider."""
+
     provider = LocalKeyProvider()
     spec = KeySpec(
         klass=KeyClass.symmetric,
@@ -50,15 +69,34 @@ async def run_example() -> str:
     )
     created = await provider.create_key(spec)
     fetched = await provider.get_key(created.kid, include_secret=True)
-    print(f"Retrieved key: {fetched.kid}")
+    assert fetched.material is not None
+    return fetched.kid
 
 
-asyncio.run(run_example())
+if __name__ == "__main__":
+    print(asyncio.run(run_example()))
 ```
 
-Keys may be rotated and exported as a JWKS:
+### Rotate, export, and derive
+
+Once you have a provider instance, additional asynchronous helpers are
+available to manage keys and metadata:
 
 ```python
+# Rotate the current key in-place (keeps the same KID with a new version)
 rotated = await provider.rotate_key(created.kid)
+
+# List available versions for auditing or debugging
+versions = await provider.list_versions(created.kid)
+
+# Export public material
+jwk = await provider.get_public_jwk(created.kid)
 jwks = await provider.jwks()
+
+# Destroy keys when finished
+await provider.destroy_key(created.kid)
+
+# Generate bytes or derive new material locally
+random_bytes = await provider.random_bytes(32)
+derived = await provider.hkdf(b"ikm", salt=b"salt", info=b"context", length=32)
 ```

--- a/pkgs/standards/swarmauri_keyprovider_local/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_local/pyproject.toml
@@ -36,6 +36,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_keyprovider_local/tests/examples/test_readme_example.py
+++ b/pkgs/standards/swarmauri_keyprovider_local/tests/examples/test_readme_example.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import asyncio
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+
+
+@pytest.mark.example
+def test_readme_quickstart_example_runs() -> None:
+    """Execute the Quickstart snippet from the README to keep it accurate."""
+
+    readme = README_PATH.read_text(encoding="utf-8")
+    match = re.search(r"## Quickstart.*?```python\n(.*?)```", readme, re.DOTALL)
+    assert match, "Could not locate Quickstart python example in README"
+
+    code = textwrap.dedent(match.group(1)).strip()
+    namespace: dict[str, object] = {"__name__": "__readme__"}
+    exec(code, namespace)  # noqa: S102 - executing trusted documentation example
+
+    run_example = namespace.get("run_example")
+    assert callable(run_example), "README example must define run_example()"
+
+    result = asyncio.run(run_example())  # type: ignore[arg-type]
+    assert isinstance(result, str)
+    assert result


### PR DESCRIPTION
## Summary
- expand the local key provider README with capability details, pip/Poetry/uv install guidance, and a quickstart snippet that mirrors the shipped example
- register an `example` pytest marker for the package so example tests are recognized
- add a README-backed pytest that executes the documented quickstart to keep the docs trustworthy

## Testing
- uv run --directory pkgs/standards --package swarmauri_keyprovider_local pytest swarmauri_keyprovider_local

------
https://chatgpt.com/codex/tasks/task_b_68ca77ddab948331b26f62b6fccd7eac