### PR TITLE
docs: sync file key provider README example

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_file/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_file/README.md
@@ -18,13 +18,36 @@
 
 # Swarmauri File Key Provider
 
-A file-backed key provider implementing the `KeyProviderBase` interface.
-It manages symmetric and asymmetric keys on disk and exports public material via JWK/JWKS.
+`FileKeyProvider` is a file-backed implementation of the `KeyProviderBase`
+interface. It persists each key beneath a `keys/<kid>/v<version>/` directory,
+captures metadata in `meta.json`, and exports public material in PEM or JWK
+form. The provider supports the same lifecycle semantics as the in-memory
+providers, but every operation is durable on disk.
+
+## Highlights
+
+- Generate symmetric AES-256-GCM keys and asymmetric Ed25519, X25519, RSA
+  (OAEP/PSS), or ECDSA (P-256) key material.
+- Import existing keys while preserving private material when allowed by the
+  selected `ExportPolicy`.
+- Rotate versions in-place, destroy versions or entire keys, and list
+  historical versions stored on disk.
+- Publish public material as individual JWKs or aggregate JWKS documents and
+  expose HKDF and random byte helpers.
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_keyprovider_file
+
+# Poetry
+poetry add swarmauri_keyprovider_file
+
+# uv
+uv add swarmauri_keyprovider_file
 ```
 
 ## Usage
@@ -60,6 +83,10 @@ async def run_example() -> str:
 
 asyncio.run(run_example())
 ```
+
+`FileKeyProvider` is asynchronous—every lifecycle method returns a
+`KeyRef`. Use `include_secret=True` when retrieving keys that allow private
+material export so symmetric key bytes are loaded from disk.
 
 ## Entry Point
 

--- a/pkgs/standards/swarmauri_keyprovider_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_file/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_keyprovider_file/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_keyprovider_file/tests/test_readme_example.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def _extract_usage_snippet() -> str:
+    text = README_PATH.read_text()
+    match = re.search(r"```python\n(.*?)\n```", text, re.DOTALL)
+    if not match:
+        raise AssertionError("Usage example not found in README.md")
+    return match.group(1)
+
+
+@pytest.mark.example
+def test_readme_usage_example_runs(capsys):
+    code = _extract_usage_snippet()
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(code, namespace)
+    captured = capsys.readouterr()
+    assert "Loaded key:" in captured.out


### PR DESCRIPTION
## Summary
- align the FileKeyProvider README with its on-disk behaviour and expand installation guidance for pip, Poetry, and uv
- clarify asynchronous usage expectations in the documentation
- add a README-backed pytest that exercises the documented usage example and register the `example` marker

## Testing
- uv run --directory pkgs/standards/swarmauri_keyprovider_file --package swarmauri_keyprovider_file pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca77dbf4188331a9870d8cdb621599