### PR TITLE
Document evaluator pool usage and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
@@ -22,27 +22,92 @@
 
 # Swarmauri Evaluatorpool Accessibility
 
-A package providing accessibility and readability evaluators for Swarmauri, aggregating classic readability metrics into a single pool.
+Accessibility-focused evaluator pool for Swarmauri programs. The pool bundles a
+set of classic readability metrics (Automated Readability Index, Coleman–Liau,
+Flesch–Kincaid Grade, Flesch Reading Ease, and Gunning Fog) and normalises their
+scores onto a single 0–1 scale where higher values mean easier-to-read content.
 
 ## Installation
+
+### pip
 
 ```bash
 pip install swarmauri_evaluatorpool_accessibility
 ```
 
+### Poetry
+
+```bash
+poetry add swarmauri_evaluatorpool_accessibility
+```
+
+### uv
+
+```bash
+# Install into the current environment
+uv pip install swarmauri_evaluatorpool_accessibility
+
+# Or add it to the project pyproject.toml
+uv add swarmauri_evaluatorpool_accessibility
+```
+
 ## Usage
+
+`AccessibilityEvaluatorPool` is a registered `EvaluatorPoolBase` component. It
+expects a sequence of Swarmauri `Program` objects, runs the configured
+evaluators concurrently, then returns standard `EvalResultBase` instances with
+the aggregated score and detailed metadata for every evaluator.
+
+### Example
 
 ```python
 from swarmauri_evaluatorpool_accessibility.AccessibilityEvaluatorPool import AccessibilityEvaluatorPool
 from swarmauri_standard.programs.Program import Program
 
 program = Program(content={"example.txt": "This is a simple sentence. Here is another one."})
-pool = AccessibilityEvaluatorPool()
-result = pool.evaluate(program)
 
-print(result.score)       # aggregated accessibility score
-print(result.metadata)    # details from individual evaluators
+pool = AccessibilityEvaluatorPool()
+pool.initialize()  # spin up the thread pool once before evaluating
+
+results = pool.evaluate([program])
+result = results[0]
+
+print(f"Aggregate accessibility score: {result.score:.2f}")
+print("Per-evaluator scores:", result.metadata["evaluator_scores"])
+flesch_meta = result.metadata["evaluator_metadata"].get(
+    "FleschReadingEaseEvaluator", {}
+)
+print(
+    "Flesch interpretation:",
+    flesch_meta.get("readability_interpretation", flesch_meta.get("error", "not available")),
+)
+
+pool.shutdown()  # release resources when finished
 ```
+
+### Result structure
+
+Each entry returned from `evaluate` is an `EvalResultBase` with:
+
+- `score`: the weighted mean of the evaluator scores mapped to the 0–1 range.
+- `metadata["evaluator_scores"]`: raw scores keyed by evaluator name.
+- `metadata["evaluator_metadata"]`: evaluator-specific metadata (e.g. sentence
+  counts, syllable estimates, interpretation strings).
+- `metadata["aggregate_score"]`: mirrors `.score` for convenience.
+
+You can customise the weighting of each evaluator by passing a `weights`
+dictionary (name → float) when constructing the pool.
+
+### Notes
+
+- The pool automatically registers the bundled evaluators when no explicit list
+  is provided. You can pass your own evaluators that satisfy the `IEvaluate`
+  interface to override or extend the defaults.
+- `FleschReadingEaseEvaluator` downloads NLTK's `punkt` tokenizer and
+  `cmudict` pronunciation dictionary on first use. Set `NLTK_DATA_DIR` to point
+  to a writable cache location if required. When these resources are not
+  available the evaluator reports an `"error"` entry in its metadata instead of
+  raising an exception.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/pyproject.toml
@@ -74,6 +74,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: README-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_readme_example.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_readme_example.py
@@ -1,0 +1,37 @@
+"""Execute the README usage example to ensure it stays valid."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _readme_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "README.md"
+
+
+def _extract_first_python_block(text: str) -> str:
+    match = re.search(r"```python\n(.*?)```", text, re.DOTALL)
+    if not match:
+        raise AssertionError("README is missing a python usage example")
+    return match.group(1)
+
+
+@pytest.mark.example
+def test_readme_usage_example_executes() -> None:
+    """Run the README example verbatim."""
+
+    code = _extract_first_python_block(_readme_path().read_text(encoding="utf-8"))
+    namespace: dict[str, object] = {}
+
+    exec(compile(code, str(_readme_path()), "exec"), namespace)
+
+    result = namespace.get("result")
+    assert result is not None, "README example should assign the evaluation result"
+    assert hasattr(result, "score"), "Result should expose a score attribute"
+
+    pool = namespace.get("pool")
+    if hasattr(pool, "shutdown"):
+        pool.shutdown()


### PR DESCRIPTION
## Summary
- expand the evaluator pool README with accurate usage notes, pip/Poetry/uv installation guidance, and clearer metadata expectations
- register a pytest `example` marker and add a README-backed test that executes the documented example

## Testing
- `uv run --directory pkgs/standards/swarmauri_evaluatorpool_accessibility --package swarmauri_evaluatorpool_accessibility pytest tests/unit/test_readme_example.py`
- `uv run --directory pkgs/standards/swarmauri_evaluatorpool_accessibility --package swarmauri_evaluatorpool_accessibility pytest` *(fails: legacy tests reference removed APIs and NLTK resources)*

------
https://chatgpt.com/codex/tasks/task_b_68ca77ba8e54833194e43bcc857257cf