### PR TITLE
docs: refresh peagen README and add example test

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -123,6 +123,7 @@ markers = [
     "perf: Performance tests that measure execution time and resource usage",
     "smoke: comprehensive smoke tests against live services",
     "e2e: end-to-end workflow tests",
+    "example: README-backed documentation examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/peagen/tests/test_readme_example.py
+++ b/pkgs/standards/peagen/tests/test_readme_example.py
@@ -1,0 +1,35 @@
+"""Execute README examples to ensure documentation stays accurate."""
+
+from __future__ import annotations
+
+import io
+import re
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
+CODE_BLOCK_PATTERN = re.compile(r"```python\n(.*?)```", re.DOTALL)
+
+
+@pytest.mark.example
+def test_sort_file_records_snippet_executes() -> None:
+    """Run the README dependency-ordering example and verify the output."""
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    blocks = CODE_BLOCK_PATTERN.findall(readme_text)
+    target_block = next(
+        (block for block in blocks if "sort_file_records" in block), None
+    )
+    assert target_block is not None, "README sort_file_records example not found"
+
+    stdout = io.StringIO()
+    namespace: dict[str, object] = {}
+    with redirect_stdout(stdout):
+        exec(compile(target_block, str(README_PATH), "exec"), namespace)
+
+    output_lines = stdout.getvalue().strip().splitlines()
+    assert output_lines == [
+        "['README.md', 'components/db.py', 'components/service.py']",
+        "3",
+    ]


### PR DESCRIPTION
## Summary
- update the peagen README to reflect the current CLI layout, installation options, and Python dependency-ordering example
- add a README-backed pytest that executes the documented `sort_file_records` snippet
- register the new `example` pytest marker so the test suite recognises README examples

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen -- ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen -- pytest` *(fails: gateway imports require an active asyncio event loop during collection)*
- `uv run --directory pkgs/standards/peagen --package peagen -- pytest tests/test_readme_example.py`


------
https://chatgpt.com/codex/tasks/task_b_68ca77ab95bc8331a41a60557e736013