### PR TITLE
Align NMF embedding README with implementation

### DIFF
--- a/pkgs/standards/swarmauri_embedding_nmf/README.md
+++ b/pkgs/standards/swarmauri_embedding_nmf/README.md
@@ -18,34 +18,85 @@
 
 # Swarmauri Embedding Nmf
 
-A Non-negative Matrix Factorization (NMF) based embedding implementation for text data processing in the Swarmauri ecosystem.
+`swarmauri_embedding_nmf` provides a Non-negative Matrix Factorization (NMF)
+implementation that converts collections of documents into dense numeric
+vectors. Under the hood it combines `TfidfVectorizer` and `NMF` from
+scikit-learn and wraps the results in Swarmauri's [`Vector`](https://github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_standard/swarmauri_standard/vectors/Vector.py)
+type so the embeddings fit seamlessly into the wider ecosystem.
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_embedding_nmf
+
+# Poetry
+poetry add swarmauri_embedding_nmf
+
+# uv
+uv add swarmauri_embedding_nmf
 ```
 
-## Usage
-Here's a basic example of how to use the NMF Embedding:
+## Quickstart
+
+```python
+from swarmauri_embedding_nmf import NmfEmbedding
+
+documents = [
+    "This is the first document",
+    "This is the second document",
+    "And this is the third one",
+]
+
+# n_components must not exceed the number of documents or unique terms
+embedder = NmfEmbedding(n_components=3)
+
+# Fit and transform the documents into Swarmauri Vector objects
+vectors = embedder.fit_transform(documents)
+
+for document, vector in zip(documents, vectors):
+    print(document, vector.value)
+
+print("Vocabulary:", embedder.extract_features())
+
+# Transform a new document after fitting
+new_vector = embedder.infer_vector("This is a new document")
+print("New vector:", new_vector.value)
+```
+
+`fit_transform` and `infer_vector` both return `Vector` instances. Access the
+numerical data through each vector's `.value` attribute when interacting with
+other libraries or serialising results.
+
+### Persisting trained models
+
+After training you can persist the TF-IDF vectoriser and NMF model:
+
+```python
+embedder.save_model("nmf_embedding")
+embedder.load_model("nmf_embedding")
+```
+
+The `save_model` method writes two files with `_tfidf.joblib` and
+`_nmf.joblib` suffixes, and `load_model` restores the same components for
+future inference sessions.
+
+### Swarmauri plugin usage
+
+Installing this package also registers the
+`swarmauri.embeddings.NmfEmbedding` entry point. When you already depend on
+the `swarmauri` meta-package you can continue to import the embedder via the
+registry:
 
 ```python
 from swarmauri.embeddings.NmfEmbedding import NmfEmbedding
-
-# Initialize the embedder
-embedder = NmfEmbedding(n_components=10)
-
-# Example documents
-documents = ["This is the first document", "This is the second document", "And this is the third one"]
-
-# Fit and transform the documents
-vectors = embedder.fit_transform(documents)
-
-# Transform a new document
-new_vector = embedder.infer_vector("This is a new document")
 ```
 
 ## Want to help?
 
-If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+If you want to contribute to swarmauri-sdk, read up on our
+[guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md)
+that will help you get started.
 

--- a/pkgs/standards/swarmauri_embedding_nmf/pyproject.toml
+++ b/pkgs/standards/swarmauri_embedding_nmf/pyproject.toml
@@ -29,6 +29,7 @@ swarmauri_standard = { workspace = true }
 norecursedirs = ["combined", "scripts"]
 markers = [
     "test: standard test",
+    "example: Example usage tests",
     "unit: Unit tests",
     "i9n: Integration tests",
     "r8n: Regression tests",

--- a/pkgs/standards/swarmauri_embedding_nmf/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_embedding_nmf/tests/example/test_readme_example.py
@@ -1,0 +1,24 @@
+import pytest
+
+from swarmauri_embedding_nmf import NmfEmbedding
+
+
+documents = [
+    "This is the first document",
+    "This is the second document",
+    "And this is the third one",
+]
+
+
+@pytest.mark.example
+def test_readme_usage_example() -> None:
+    embedder = NmfEmbedding(n_components=3)
+
+    vectors = embedder.fit_transform(documents)
+
+    assert len(vectors) == len(documents)
+    assert all(len(vector.value) == embedder.n_components for vector in vectors)
+    assert embedder.extract_features()
+
+    new_vector = embedder.infer_vector("This is a new document")
+    assert len(new_vector.value) == embedder.n_components


### PR DESCRIPTION
## Summary
- refresh the NMF embedding README with accurate quickstart guidance, install commands for pip/Poetry/uv, and plugin/persistence notes
- register a pytest ``example`` marker and add a README-backed test that exercises the documented workflow

## Testing
- uv run --directory pkgs/standards/swarmauri_embedding_nmf --package swarmauri_embedding_nmf ruff format .
- uv run --directory pkgs/standards/swarmauri_embedding_nmf --package swarmauri_embedding_nmf ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_embedding_nmf --package swarmauri_embedding_nmf pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7788812483318e0bf8cdd57342b1