### PR TITLE
Document hierarchical key provider quickstart and test README example

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
@@ -23,8 +23,154 @@ key operations across multiple child providers. It implements the
 `IKeyProvider` interface and exposes a single `HierarchicalKeyProvider`
 class.
 
+## Overview
+
+`HierarchicalKeyProvider` composes a mapping of named child providers and
+routes every key operation to the correct child according to declarative
+policies.  It offers:
+
+- **Create/import routing** – specify ordered [`CreateRule`](#routing-policy)
+  objects that match key class, algorithm, usage, or export policy. The first
+  rule that matches a `KeySpec` wins.
+- **Automatic discovery** – when looking up an unknown key identifier (KID)
+  the provider probes each child until it finds the owning provider and caches
+  the association for future calls.
+- **Persistent indexing** – optionally persist the learned KID → provider map
+  to JSON via the `index_file` argument so the routing cache survives process
+  restarts.
+- **Capability passthrough** – rotate, destroy, list, JWKS, HKDF, and random
+  byte requests are forwarded transparently to the owning (or designated)
+  child provider. JWKS responses are merged across children while avoiding
+  duplicate KIDs.
+- **Heuristic fallback** – if no policy matches a create/import request the
+  provider falls back to sensible defaults: asymmetric keys prefer children
+  named like KMS/PKCS#11, symmetric keys prefer local/file providers, and
+  otherwise the first registered child is used.
+
 ## Installation
+
+Choose the installer that matches your workflow.
+
+### pip
 
 ```bash
 pip install swarmauri_keyprovider_hierarchical
 ```
+
+### Poetry
+
+```bash
+poetry add swarmauri_keyprovider_hierarchical
+```
+
+### uv
+
+```bash
+uv venv  # create (or reuse) a virtual environment
+source .venv/bin/activate
+uv pip install swarmauri_keyprovider_hierarchical
+```
+
+If you are already inside a uv-managed environment you can shorten the last
+two steps to `uv pip install swarmauri_keyprovider_hierarchical`.
+
+## Quickstart
+
+The example below wires two `LocalKeyProvider` instances behind a
+`HierarchicalKeyProvider`. Symmetric keys are routed to a local provider while
+asymmetric keys land on a provider named `kms`. The composite provider also
+serves random bytes and JWKS responses for all children.
+
+<!-- example-start -->
+```python
+"""Create keys across multiple providers with policy-driven routing."""
+
+import asyncio
+
+from swarmauri_keyprovider_hierarchical import HierarchicalKeyProvider, CreateRule
+from swarmauri_keyprovider_local import LocalKeyProvider
+from swarmauri_core.keys.types import (
+    ExportPolicy,
+    KeyAlg,
+    KeyClass,
+    KeySpec,
+    KeyUse,
+)
+
+
+async def main() -> None:
+    children = {
+        "kms": LocalKeyProvider(),
+        "local": LocalKeyProvider(),
+    }
+    provider = HierarchicalKeyProvider(
+        children,
+        create_policy=[
+            CreateRule(provider="kms", klass=KeyClass.asymmetric),
+            CreateRule(provider="local", klass=KeyClass.symmetric),
+        ],
+        randomness_provider="local",  # designate a child for random_bytes
+    )
+
+    symmetric_spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+    asymmetric_spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+    )
+
+    symmetric_ref = await provider.create_key(symmetric_spec)
+    asymmetric_ref = await provider.create_key(asymmetric_spec)
+    random_token = await provider.random_bytes(16)
+    jwks = await provider.jwks()
+
+    print(f"Symmetric key kid: {symmetric_ref.kid}")
+    print(f"Asymmetric key kid: {asymmetric_ref.kid}")
+    print(f"Random token length: {len(random_token)} bytes")
+    print(f"JWKS entries: {len(jwks['keys'])}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+<!-- example-end -->
+
+Running the script prints the generated key identifiers, confirms the random
+token length, and shows how many public keys were merged into the JWKS
+document.
+
+## Routing policy
+
+`CreateRule` is a dataclass that narrows matching by any combination of
+attributes:
+
+- `provider` (required): the name of the child provider to route to.
+- `klass`: limit matches to a specific `KeyClass` (symmetric or asymmetric).
+- `algs`: iterable of allowed `KeyAlg` values.
+- `uses`: iterable of desired `KeyUse` values; at least one requested use must
+  intersect with the spec.
+- `export_policies`: iterable of `ExportPolicy` values.
+
+Rules are evaluated in order, and the first match wins. When an import policy
+is not supplied, create rules are re-used for imports.
+
+## Index persistence & discovery
+
+Pass `index_file` to persist the in-memory KID → provider cache as JSON. On
+startup, any known mappings are re-loaded (invalid provider names are skipped).
+When a lookup is made for an unknown KID the provider probes each child with a
+`get_key` call; if a child recognizes the KID the mapping is remembered and
+future calls avoid probing. Destroying a key (without specifying a version)
+removes the cached entry.
+
+## Randomness & key derivation
+
+Use the `randomness_provider` and `derivation_provider` keyword arguments to
+pin those helper methods to a specific child. If they are omitted the first
+registered provider is used for both random bytes and HKDF requests.

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "perf: Performance tests",
     "func: Functional tests",
     "rfc: RFC compliance tests",
+    "example: Documentation examples",
 ]
 benchmark_min_rounds = 1
 timeout = 300

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_readme_example.py
@@ -1,0 +1,45 @@
+"""Ensure the README quickstart snippet stays runnable."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
+
+
+@pytest.mark.example
+def test_readme_quickstart_example(tmp_path, monkeypatch):
+    """Execute the README quickstart example as a regression test."""
+    text = README_PATH.read_text(encoding="utf-8")
+    start_marker = "<!-- example-start -->"
+    end_marker = "<!-- example-end -->"
+    try:
+        start = text.index(start_marker) + len(start_marker)
+        end = text.index(end_marker, start)
+    except ValueError as exc:  # pragma: no cover - explicit failure path
+        raise AssertionError("README example markers missing") from exc
+
+    section = text[start:end]
+    match = re.search(r"```python\n(.*?)\n```", section, re.DOTALL)
+    if not match:
+        raise AssertionError("No python code block found in README example section")
+
+    monkeypatch.chdir(tmp_path)
+    code = match.group(1)
+    stdout = io.StringIO()
+    exec_globals = {"__name__": "__main__"}
+
+    with contextlib.redirect_stdout(stdout):
+        exec(compile(code, str(README_PATH), "exec"), exec_globals)
+
+    output = stdout.getvalue()
+    assert "Symmetric key kid:" in output
+    assert "Asymmetric key kid:" in output
+    assert "Random token length:" in output
+    assert "JWKS entries:" in output


### PR DESCRIPTION
## Summary
- expand the hierarchical key provider README with an overview of routing behaviour, pip/Poetry/uv installation guidance, and a runnable quickstart example
- add a pytest that executes the README quickstart snippet and register a pytest marker for documentation examples

## Testing
- uv run --directory pkgs/standards/swarmauri_keyprovider_hierarchical --package swarmauri_keyprovider_hierarchical ruff format .
- uv run --directory pkgs/standards/swarmauri_keyprovider_hierarchical --package swarmauri_keyprovider_hierarchical ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_keyprovider_hierarchical --package swarmauri_keyprovider_hierarchical pytest -m example

------
https://chatgpt.com/codex/tasks/task_b_68ca77dbd57083319e79e024d20a77c3