### PR TITLE
Align auth middleware README and add example test

### DIFF
--- a/pkgs/standards/swarmauri_middleware_auth/README.md
+++ b/pkgs/standards/swarmauri_middleware_auth/README.md
@@ -27,34 +27,150 @@ JWT authentication middleware for Swarmauri and FastAPI applications.
 
 ## Features
 
-- Validates `Bearer` tokens in incoming requests
-- Verifies signatures using `swarmauri_signing_jws`
-- Supports expiration, audience and issuer checks
-- Provides hooks for custom claim validation
-- Offers a utility to verify tokens outside the middleware
+- Accepts HTTP `Authorization` headers with `Bearer` tokens and rejects
+  missing or malformed credentials with a `401` response.
+- Verifies JWT signatures through `swarmauri_signing_jws.JwsSignerVerifier`
+  using the configured secret and algorithm (default `HS256`).
+- Enforces expiration by default and can optionally require matching
+  audience (`aud`) and issuer (`iss`) claims.
+- Requires `sub` and `iat` claims and exposes
+  `_validate_custom_claims` for additional validation logic.
+- Stores the decoded payload on `request.state.user` for downstream
+  handlers.
+- Provides a `verify_token_manually` utility to inspect tokens outside of
+  the middleware lifecycle.
 
 ## Installation
 
+Install the package with your preferred Python packaging tool:
+
 ```bash
 pip install swarmauri_middleware_auth
-# or
+```
+
+```bash
 poetry add swarmauri_middleware_auth
 ```
 
+```bash
+uv pip install swarmauri_middleware_auth
+```
+
+## Configuration
+
+`AuthMiddleware` accepts the following arguments:
+
+- `secret_key` (**required**) – shared secret used to validate
+  HMAC-signed JWTs (must be at least 32 bytes for HMAC algorithms).
+- `algorithm` (default `"HS256"`) – JWT algorithm identifier supported by
+  `swarmauri_signing_jws`.
+- `verify_exp` (default `True`) – toggle to enforce the `exp` claim.
+- `verify_aud` (default `False`) – toggle to enforce the `aud` claim
+  matches the provided `audience`.
+- `audience` – expected `aud` claim when `verify_aud` is enabled.
+- `issuer` – expected `iss` claim.
+- Additional keyword arguments are forwarded to `MiddlewareBase`.
+
+Tokens missing required claims (`sub`, `iat`) or failing any validation
+step raise an `HTTPException` with a `401` status code.
+
 ## Usage
 
+Instantiate `AuthMiddleware` and delegate to its `dispatch` coroutine from a
+FastAPI middleware hook. Use FastAPI's HTTP exception handler to translate
+authentication failures into proper responses:
+
 ```python
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exception_handlers import http_exception_handler
+
 from swarmauri_middleware_auth import AuthMiddleware
 
-app = FastAPI()
-app.add_middleware(
-    AuthMiddleware,
-    secret_key="supersecret",
-    issuer="my-service",
-    audience="my-audience",
+SECRET_KEY = "supersecret-key-with-32-bytes-min!"
+ISSUER = "my-service"
+AUDIENCE = "my-audience"
+
+auth_middleware = AuthMiddleware(
+    secret_key=SECRET_KEY,
+    issuer=ISSUER,
+    audience=AUDIENCE,
+    verify_aud=True,
 )
+
+app = FastAPI()
+
+
+@app.middleware("http")
+async def auth_guard(request: Request, call_next):
+    try:
+        return await auth_middleware.dispatch(request, call_next)
+    except HTTPException as exc:
+        return await http_exception_handler(request, exc)
+
+
+@app.get("/protected")
+async def protected(request: Request):
+    return {"subject": request.state.user["sub"]}
 ```
+
+## Issuing tokens for local testing
+
+The middleware expects tokens to include `sub`, `iat`, and (by default)
+`exp`. The snippet below produces a short-lived token compatible with the
+configuration above:
+
+```python
+import asyncio
+import time
+
+from swarmauri_core.crypto.types import JWAAlg
+from swarmauri_signing_jws import JwsSignerVerifier
+
+SECRET_KEY = "supersecret-key-with-32-bytes-min!"
+ISSUER = "my-service"
+AUDIENCE = "my-audience"
+
+
+async def issue_token() -> str:
+    signer = JwsSignerVerifier()
+    return await signer.sign_compact(
+        payload={
+            "sub": "user123",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 300,
+            "aud": AUDIENCE,
+            "iss": ISSUER,
+        },
+        alg=JWAAlg.HS256,
+        key={"kind": "raw", "key": SECRET_KEY, "alg": "HS256"},
+        typ="JWT",
+    )
+
+
+token = asyncio.run(issue_token())
+```
+
+## Custom claim validation
+
+Override `_validate_custom_claims` to enforce additional rules. Raise
+`InvalidTokenError` when a token should be rejected:
+
+```python
+from swarmauri_middleware_auth import AuthMiddleware, InvalidTokenError
+
+
+class RoleCheckingMiddleware(AuthMiddleware):
+    def _validate_custom_claims(self, payload: dict) -> None:
+        super()._validate_custom_claims(payload)
+        if payload.get("role") != "admin":
+            raise InvalidTokenError("Admin role is required")
+```
+
+## Manual verification helper
+
+Use `verify_token_manually` to synchronously inspect tokens without FastAPI
+middleware plumbing. The method returns the decoded payload when valid and
+`None` otherwise.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_middleware_auth/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_auth/pyproject.toml
@@ -38,6 +38,7 @@ markers = [
     "test: standard test",
     "unit: Unit tests",
     "i9n: Integration tests",
+    "example: Documentation-backed usage examples",
     "r8n: Regression tests",
     "timeout: mark test to timeout after X seconds",
     "xpass: Expected passes",

--- a/pkgs/standards/swarmauri_middleware_auth/tests/unit/test_AuthMiddleware.py
+++ b/pkgs/standards/swarmauri_middleware_auth/tests/unit/test_AuthMiddleware.py
@@ -96,7 +96,10 @@ def invalid_signature_token(secret_key):
         "role": "user",
     }
     # Use a different secret key to create invalid signature
-    return _make_token(payload, "wrong-secret-key")
+    return _make_token(
+        payload,
+        "wrong-secret-key-with-a-length-of-at-least-thirty-two-bytes",
+    )
 
 
 @pytest.fixture

--- a/pkgs/standards/swarmauri_middleware_auth/tests/unit/test_readme_example.py
+++ b/pkgs/standards/swarmauri_middleware_auth/tests/unit/test_readme_example.py
@@ -1,0 +1,67 @@
+"""Execute the README usage example to guard against regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from swarmauri_core.crypto.types import JWAAlg
+from swarmauri_signing_jws import JwsSignerVerifier
+
+
+@pytest.mark.example
+def test_readme_usage_example_executes() -> None:
+    """Run the README usage example and confirm it protects a route."""
+
+    readme_path = Path(__file__).resolve().parents[2] / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8")
+
+    match = re.search(r"## Usage.*?```python\n(?P<code>.*?)```", readme_text, re.S)
+    assert match is not None, "Usage example not found in README.md"
+
+    namespace: dict[str, object] = {"__name__": "__test__"}
+    exec(match.group("code"), namespace)  # noqa: S102 - executing documented example
+
+    app = namespace.get("app")
+    auth_middleware = namespace.get("auth_middleware")
+    secret_key = namespace.get("SECRET_KEY")
+    issuer = namespace.get("ISSUER")
+    audience = namespace.get("AUDIENCE")
+
+    assert app is not None, "Example did not define 'app'"
+    assert auth_middleware is not None, "Example did not define 'auth_middleware'"
+    assert secret_key is not None, "Example did not define 'SECRET_KEY'"
+    assert issuer is not None, "Example did not define 'ISSUER'"
+    assert audience is not None, "Example did not define 'AUDIENCE'"
+
+    client = TestClient(app, raise_server_exceptions=False)  # type: ignore[arg-type]
+
+    unauthenticated = client.get("/protected")
+    assert unauthenticated.status_code == 401
+
+    signer = JwsSignerVerifier()
+    token = asyncio.run(
+        signer.sign_compact(
+            payload={
+                "sub": "user123",
+                "iat": int(time.time()),
+                "exp": int(time.time()) + 60,
+                "aud": audience,
+                "iss": issuer,
+            },
+            alg=JWAAlg.HS256,
+            key={"kind": "raw", "key": secret_key, "alg": "HS256"},
+            typ="JWT",
+        )
+    )
+
+    authenticated = client.get(
+        "/protected", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert authenticated.status_code == 200
+    assert authenticated.json() == {"subject": "user123"}


### PR DESCRIPTION
## Summary
- document the actual AuthMiddleware behavior, configuration, and installation options including uv usage
- add a README-backed FastAPI example that enforces request validation and demonstrates issuing compatible tokens
- register an `example` pytest marker and add a regression test that executes the README example while fixing HMAC test secrets

## Testing
- `uv run --directory pkgs/standards/swarmauri_middleware_auth --package swarmauri_middleware_auth ruff format .`
- `uv run --directory pkgs/standards/swarmauri_middleware_auth --package swarmauri_middleware_auth ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_middleware_auth --package swarmauri_middleware_auth pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ca77ce08dc833195818d24928c440b