### PR TITLE
docs: refresh README and add example test for any usage evaluator

### DIFF
--- a/pkgs/standards/swarmauri_evaluator_anyusage/README.md
+++ b/pkgs/standards/swarmauri_evaluator_anyusage/README.md
@@ -22,30 +22,83 @@
 
 # Swarmauri Evaluator AnyUsage
 
-Evaluator that detects and penalizes use of the `Any` type in Python code.
+Evaluator that detects and penalizes usage of the `typing.Any` type in Python source files.
 
 ## Features
 
-- Flags `typing.Any` occurrences across your codebase.
-- Produces a penalty score proportional to the number of findings.
-- Reports file names and line numbers for quick remediation.
+- Recursively scans every `.py` file under `program.path`, falling back to the current
+  working directory when that attribute is missing.
+- Uses the Python AST to capture imports and annotations plus a regex pass to
+  backfill edge cases (e.g., syntax errors).
+- Deducts `penalty_per_occurrence` (default `0.1`) for each finding and caps the
+  deduction at `max_penalty` (default `1.0`), yielding a normalized score between `0.0`
+  and `1.0` where higher is better.
+- Returns rich metadata that lists the number of files analyzed, the total `Any`
+  occurrences, and per-file line numbers and snippets to accelerate remediation.
 
 ## Installation
 
+Choose the tool that best fits your workflow:
+
 ```bash
+# pip
 pip install swarmauri_evaluator_anyusage
+
+# Poetry
+poetry add swarmauri_evaluator_anyusage
+
+# uv
+uv add swarmauri_evaluator_anyusage
 ```
 
 ## Usage
 
 ```python
+from pathlib import Path
+
+from swarmauri_base.programs.ProgramBase import ProgramBase
 from swarmauri_evaluator_anyusage import AnyTypeUsageEvaluator
 
-# 'program' is any swarmauri_core Program pointing to your source files.
-evaluator = AnyTypeUsageEvaluator()
+
+workspace = Path("path/to/project")
+
+program = ProgramBase()
+program.name = workspace.name
+program.path = str(workspace)  # AnyTypeUsageEvaluator walks this directory on disk
+
+evaluator = AnyTypeUsageEvaluator(penalty_per_occurrence=0.1, max_penalty=1.0)
 score, metadata = evaluator.evaluate(program)
-print(score, metadata)
+
+print(f"Score: {score:.2f}")
+print("Files analyzed:", metadata["files_analyzed"])
+print("Any usages:", metadata["total_any_occurrences"])
+
+for report in metadata["detailed_occurrences"]:
+    print("-", report["file"])
+    for occurrence in report["occurrences"]:
+        print(f"  line {occurrence['line']}: {occurrence['context']}")
+
+# If you already depend on `swarmauri_standard`, import
+# `from swarmauri_standard.programs.Program import Program` and replace the
+# ProgramBase construction above with `Program.from_workspace(workspace)`
+# before setting `program.path` to keep the on-disk directory in sync with
+# your Program content.
 ```
+
+### Metadata reference
+
+The evaluation metadata contains:
+
+- `files_analyzed`: Number of Python files inspected.
+- `total_any_occurrences`: Count of detected `Any` usages across all files.
+- `penalty_applied`: The aggregate deduction applied to the score.
+- `detailed_occurrences`: A list with one entry per file containing the absolute path
+  and the line/context pairs for each finding. Multiple entries can share a line number
+  when both the parameter and return annotations use `Any`; the `context` value explains
+  the exact usage (import, parameter annotation, return annotation, etc.).
+- `execution_time`: Added by `EvaluatorBase` to show how long the evaluation took.
+
+Use these fields to build dashboards, enforce quality gates, or guide manual reviews.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_evaluator_anyusage/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_anyusage/pyproject.toml
@@ -60,6 +60,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_evaluator_anyusage/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_evaluator_anyusage/tests/example/test_readme_example.py
@@ -1,0 +1,50 @@
+"""README-backed usage tests for swarmauri_evaluator_anyusage."""
+
+from pathlib import Path
+
+import pytest
+
+from swarmauri_base.programs.ProgramBase import ProgramBase
+from swarmauri_evaluator_anyusage import AnyTypeUsageEvaluator
+
+
+@pytest.mark.example
+def test_readme_usage_example(tmp_path: Path) -> None:
+    """Execute the README usage example end-to-end."""
+
+    module = tmp_path / "module.py"
+    module.write_text(
+        (
+            "from typing import Any\n\n"
+            "value: Any = 1\n\n"
+            "\n"
+            "def use(value: Any) -> Any:\n"
+            "    return value\n"
+        ),
+        encoding="utf-8",
+    )
+
+    program = ProgramBase()
+    program.name = tmp_path.name
+    program.path = str(tmp_path)
+
+    evaluator = AnyTypeUsageEvaluator(penalty_per_occurrence=0.1, max_penalty=1.0)
+    score, metadata = evaluator.evaluate(program)
+
+    assert score == pytest.approx(0.3)
+    assert metadata["files_analyzed"] == 1
+    assert metadata["penalty_applied"] == pytest.approx(0.7)
+    assert metadata["total_any_occurrences"] == 7
+
+    assert len(metadata["detailed_occurrences"]) == 1
+    report = metadata["detailed_occurrences"][0]
+    assert report["file"].endswith("module.py")
+    contexts = {occurrence["context"] for occurrence in report["occurrences"]}
+    assert "from typing import Any" in contexts
+    assert "Any used as identifier" in contexts
+
+    for occurrence in report["occurrences"]:
+        assert "line" in occurrence
+        assert "context" in occurrence
+        assert isinstance(occurrence["line"], int)
+        assert isinstance(occurrence["context"], str)


### PR DESCRIPTION
## Summary
- expand the README to describe how the evaluator scans source trees, how scoring works, and how to install it with pip, Poetry, or uv
- document a runnable usage example that mirrors the package behaviour and details the metadata it returns
- add a README-backed pytest marked `example` and register the marker so the documentation snippet stays exercised

## Testing
- uv run --directory pkgs/standards/swarmauri_evaluator_anyusage --package swarmauri_evaluator_anyusage pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca77c626048331b3eeba0df05fc391