### PR TITLE
docs: sync swarmauri git filter README example

### DIFF
--- a/pkgs/standards/swarmauri_gitfilter_file/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_file/README.md
@@ -24,18 +24,46 @@
 
 Filesystem backed git filter for Peagen.
 
+`FileFilter` combines the `FileStorageAdapter` storage backend with the
+`GitFilterBase` helpers from `swarmauri_base`. The filter stores git-cleaned
+objects beneath a local directory, deduplicating each payload by its SHA-256
+digest and retrieving the bytes on smudge.
+
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_gitfilter_file
 ```
 
+```bash
+poetry add swarmauri_gitfilter_file
+```
+
+```bash
+uv pip install swarmauri_gitfilter_file
+```
+
 ## Usage
 
+`FileFilter.from_uri` accepts `file://` URIs and resolves them to the directory
+where objects will be stored. You can also instantiate `FileFilter` directly by
+passing an `output_dir`.
+
 ```python
+import tempfile
+from pathlib import Path
+
 from swarmauri_gitfilter_file import FileFilter
 
-filt = FileFilter.from_uri("file:///tmp/store")
-oid = filt.clean(b"hello")
-assert filt.smudge(oid) == b"hello"
+with tempfile.TemporaryDirectory() as tmpdir:
+    uri = Path(tmpdir).as_uri()
+    filt = FileFilter.from_uri(uri)
+    oid = filt.clean(b"hello")
+    assert oid.startswith("sha256:")
+    assert filt.smudge(oid) == b"hello"
 ```
+
+The returned object identifier includes the `sha256:` prefix, matching the
+digest used to deduplicate objects on disk.

--- a/pkgs/standards/swarmauri_gitfilter_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_file/pyproject.toml
@@ -44,6 +44,7 @@ markers = [
     "test: standard test",
     "unit: Unit tests",
     "i9n: Integration tests",
+    "example: Example usage tests",
     "r8n: Regression tests",
     "timeout: mark test to timeout after X seconds",
     "xpass: Expected passes",

--- a/pkgs/standards/swarmauri_gitfilter_file/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_gitfilter_file/tests/example/test_readme_example.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parent.parent.parent / "README.md"
+
+
+def _load_usage_example() -> str:
+    content = README_PATH.read_text(encoding="utf-8")
+    blocks = re.findall(r"```python\s*(.*?)```", content, re.DOTALL)
+    if not blocks:
+        raise AssertionError("README.md does not contain a Python usage example")
+    return textwrap.dedent(blocks[0]).strip()
+
+
+@pytest.mark.example
+def test_readme_usage_example_executes() -> None:
+    code = _load_usage_example()
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(code, namespace)


### PR DESCRIPTION
## Summary
- document how FileFilter stores Git-cleaned objects, expand installation guidance with pip/poetry/uv options, and update the usage example to reflect the file:// URI workflow
- execute the README usage example during tests via a new pytest marked with `example` and register the marker in the package configuration

## Testing
- uv run --directory pkgs/standards/swarmauri_gitfilter_file --package swarmauri_gitfilter_file ruff format .
- uv run --directory pkgs/standards/swarmauri_gitfilter_file --package swarmauri_gitfilter_file ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_gitfilter_file --package swarmauri_gitfilter_file pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca77bbbbe8833186cc0f460094ad94