### PR TITLE
docs: sync subprocess evaluator README with behavior

### DIFF
--- a/pkgs/standards/swarmauri_evaluator_subprocess/README.md
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/README.md
@@ -17,27 +17,132 @@
 
 # Swarmauri Evaluator Subprocess
 
-A subprocess-based evaluator for executing and measuring program performance in isolated subprocesses.
+`SubprocessEvaluator` executes programs inside sandboxed subprocesses while
+enforcing CPU, memory, and file size quotas. It captures stdout/stderr, tracks
+exit codes, and returns a normalized score plus structured metadata describing
+each run.
+
+## Highlights
+
+- Apply CPU timeouts, memory ceilings, file size limits, and process count caps
+  before user code starts (`resource.setrlimit`).
+- Automatically choose the appropriate command: launch executables directly or
+  wrap Python and shell scripts with the correct interpreter.
+- Compare stdout against an `expected_output` string and annotate mismatches in
+  the result metadata.
+- Record execution context (`command`, `args`, `working_dir`) alongside
+  collected streams for easy debugging.
+- Aggregate multiple runs with reason counts, timeout rates, and success rates
+  via `aggregate_scores`.
 
 ## Installation
 
+Pick the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_evaluator_subprocess
+
+# Poetry
+poetry add swarmauri_evaluator_subprocess
+
+# uv
+uv add swarmauri_evaluator_subprocess
 ```
 
-## Usage
+## Quickstart
+
+The example below writes a temporary Python script to disk, wraps it in a small
+`IProgram` implementation, and evaluates it inside a subprocess. The evaluator
+returns `1.0` when the exit code is in `success_exit_codes` and, when provided,
+stdout matches `expected_output`.
 
 ```python
+from pathlib import Path
+import tempfile
+
 from swarmauri_evaluator_subprocess import SubprocessEvaluator
+from swarmauri_core.programs.IProgram import DiffType, IProgram
 
-# `program` should implement `get_path()` and `is_executable()` and point to a script on disk.
-evaluator = SubprocessEvaluator()
-score, metadata = evaluator.evaluate(
-    program,
-    expected_output="hello\n",
-)
 
-print("Score:", score)
-print("Stdout:", metadata["stdout"])
+class ScriptProgram(IProgram):
+    """Minimal IProgram wrapper for a script stored on disk."""
+
+    def __init__(self, path: Path):
+        self._path = Path(path)
+
+    # Required IProgram interface methods -------------------------------
+    def diff(self, other: IProgram) -> DiffType:  # pragma: no cover - example
+        return {}
+
+    def apply_diff(self, diff: DiffType) -> "ScriptProgram":  # pragma: no cover
+        return ScriptProgram(self._path)
+
+    def validate(self) -> bool:  # pragma: no cover
+        return self._path.exists()
+
+    def clone(self) -> "ScriptProgram":  # pragma: no cover
+        return ScriptProgram(self._path)
+
+    # Methods consumed by SubprocessEvaluator ---------------------------
+    def get_path(self) -> str:
+        return str(self._path)
+
+    def is_executable(self) -> bool:
+        return False
+
+
+def run_example(expected_output: str = "hello from subprocess\n"):
+    evaluator = SubprocessEvaluator(timeout=5)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        script_path = Path(tmpdir) / "echo.py"
+        script_path.write_text("print('hello from subprocess')\n", encoding="utf-8")
+
+        program = ScriptProgram(script_path)
+
+        score, metadata = evaluator.evaluate(
+            program,
+            expected_output=expected_output,
+        )
+
+    return score, metadata
+
+
+def main():
+    score, metadata = run_example()
+    print("Score:", score)
+    print("Stdout:", metadata["stdout"].strip())
+    print("Reason:", metadata["reason"])
+
+
+if __name__ == "__main__":
+    main()
 ```
+
+### Evaluation options
+
+`SubprocessEvaluator.evaluate(program, **kwargs)` accepts runtime controls in
+addition to the evaluator's model fields:
+
+| Argument         | Description |
+| ---------------- | ----------- |
+| `args`           | List of command-line arguments appended to the prepared command. |
+| `input_data`     | String provided on stdin; useful for feeding sample input. |
+| `expected_output`| Optional stdout string; mismatches lower the score to `0.7`. |
+| `timeout`        | Overrides the evaluator's `timeout` for a single run. |
+
+### Returned metadata
+
+Each evaluation returns `(score, metadata)` where `metadata` always contains:
+
+- `stdout`, `stderr`, and `exit_code` from the subprocess.
+- `timed_out` flag plus a human-readable `reason` such as `success`,
+  `timeout`, or `exit_code_<value>`.
+- `command`, `args`, and `working_dir` to show how the program was launched.
+- `execution_time` (seconds) measured by the evaluator wrapper.
+
+When aggregating multiple runs, `aggregate_scores` adds `reason_counts`,
+`timeout_rate`, `success_rate`, and `total_executions` to the combined
+metadata so callers can evaluate fleet-wide behavior.
 

--- a/pkgs/standards/swarmauri_evaluator_subprocess/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/pyproject.toml
@@ -47,6 +47,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: README-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_evaluator_subprocess/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/tests/example/test_readme_example.py
@@ -1,0 +1,46 @@
+"""Execute the Quickstart snippet from the README to ensure it stays up-to-date."""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+
+
+def _extract_first_python_block() -> str:
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    matches = re.findall(r"```python\n(.*?)```", readme_text, flags=re.DOTALL)
+    if not matches:
+        raise AssertionError("README does not contain a Python example block")
+    return textwrap.dedent(matches[0])
+
+
+@pytest.mark.example
+def test_readme_quickstart_example_runs(capsys):
+    code = _extract_first_python_block()
+
+    namespace: dict[str, object] = {"__name__": "__README__"}
+    exec(code, namespace)  # noqa: S102 - intentional execution of documentation example
+
+    run_example = namespace.get("run_example")
+    assert callable(run_example), "README example must define run_example()"
+
+    score, metadata = run_example()
+
+    assert score == 1.0
+    assert metadata["reason"] == "success"
+    assert metadata["stdout"] == "hello from subprocess\n"
+
+    main = namespace.get("main")
+    assert callable(main), "README example must define main()"
+
+    main()
+    captured = capsys.readouterr()
+    assert "Score:" in captured.out
+    assert "Stdout:" in captured.out
+    assert "Reason:" in captured.out


### PR DESCRIPTION
## Summary
- align the subprocess evaluator README with the component’s actual behavior and document pip/Poetry/uv installation paths
- add a runnable Quickstart example that constructs a minimal `IProgram` implementation for evaluation
- introduce a README-backed pytest marked `example` to execute the documentation snippet and register the marker in pytest configuration

## Testing
- `uv run --directory pkgs/standards/swarmauri_evaluator_subprocess --package swarmauri_evaluator_subprocess ruff format .`
- `uv run --directory pkgs/standards/swarmauri_evaluator_subprocess --package swarmauri_evaluator_subprocess ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_evaluator_subprocess --package swarmauri_evaluator_subprocess pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ca77b9b06483318309f37be8e49d0f