### PR TITLE
Improve RemoteOIDC README with runnable example test

### DIFF
--- a/pkgs/standards/swarmauri_tokens_remoteoidc/README.md
+++ b/pkgs/standards/swarmauri_tokens_remoteoidc/README.md
@@ -22,10 +22,156 @@ Remote OIDC token verification service for Swarmauri.
 
 This package provides a verification-only token service that retrieves
 JSON Web Key Sets (JWKS) from a remote OpenID Connect (OIDC) issuer and
-validates JWTs in accordance with RFC 7517 and RFC 7519.
+validates JWTs in accordance with RFC 7517 and RFC 7519. It implements
+`ITokenService` and exposes an entry point named
+`RemoteOIDCTokenService`.
 
 ## Features
-- Remote OIDC discovery with JWKS caching.
-- Audience and issuer validation.
-- Optional extras for additional canonicalisation formats.
 
+- Remote OIDC discovery with JWKS caching and conditional revalidation
+  (ETag / Last-Modified).
+- Audience and issuer validation with configurable clock-skew leeway.
+- Optional extras for additional canonicalisation formats via the `cbor`
+  extra.
+- Manual refresh hook for cache priming plus a `jwks()` helper for
+  introspection.
+- Verification-only surface: `mint()` deliberately raises
+  `NotImplementedError`.
+
+## Installation
+
+### pip
+
+```bash
+pip install swarmauri_tokens_remoteoidc
+```
+
+### Poetry
+
+```bash
+poetry add swarmauri_tokens_remoteoidc
+```
+
+### uv
+
+```bash
+uv add swarmauri_tokens_remoteoidc
+```
+
+Install the optional CBOR canonicalisation helpers with the `cbor`
+extra if needed:
+
+```bash
+pip install swarmauri_tokens_remoteoidc[cbor]
+poetry add --extras cbor swarmauri_tokens_remoteoidc
+uv add swarmauri_tokens_remoteoidc[cbor]
+```
+
+## Usage
+
+1. Provide the expected OIDC issuer URL. Optionally override
+   `jwks_url` to skip discovery when you already know the JWKS endpoint.
+2. Call `refresh()` to prime caches when your process boots or after a
+   rotation signal.
+3. Await `verify()` with the JWT to validate signatures, issuer, and
+   optional audience or nonce constraints.
+
+### Example
+
+The snippet below boots a minimal HTTP server that hosts a JWKS
+containing a symmetric key. It then mints a short-lived HS256 token and
+verifies it using `RemoteOIDCTokenService`.
+
+```python
+import asyncio
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import jwt
+from jwt.utils import base64url_encode
+
+from swarmauri_tokens_remoteoidc import RemoteOIDCTokenService
+
+SECRET = b"super-secret-key"
+KEY_ID = "demo-key"
+
+
+def make_handler(jwks: dict):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path != "/jwks.json":
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            body = json.dumps(jwks).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # pragma: no cover - quiet server
+            return
+
+    return Handler
+
+
+async def main() -> None:
+    jwks = {
+        "keys": [
+            {
+                "kty": "oct",
+                "kid": KEY_ID,
+                "k": base64url_encode(SECRET).decode("ascii"),
+                "alg": "HS256",
+            }
+        ]
+    }
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(jwks))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        issuer = "https://issuer.example.com"
+        jwks_url = f"http://127.0.0.1:{server.server_address[1]}/jwks.json"
+
+        service = RemoteOIDCTokenService(
+            issuer=issuer,
+            jwks_url=jwks_url,
+            expected_alg_whitelist=("HS256",),
+        )
+
+        now = int(time.time())
+        token = jwt.encode(
+            {
+                "iss": issuer,
+                "aud": "my-audience",
+                "sub": "user-123",
+                "iat": now,
+                "exp": now + 60,
+            },
+            SECRET,
+            algorithm="HS256",
+            headers={"kid": KEY_ID},
+        )
+
+        service.refresh(force=True)
+        claims = await service.verify(token, audience="my-audience")
+        print(f"Verified subject: {claims['sub']}")
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+The service performs JWKS discovery or fetch, validates the token
+signature and issuer, and returns the decoded claims when verification
+succeeds. Cache entries refresh automatically based on `cache_ttl_s` or
+manually via `refresh(force=True)`.

--- a/pkgs/standards/swarmauri_tokens_remoteoidc/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_remoteoidc/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_tokens_remoteoidc/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_tokens_remoteoidc/tests/example/test_readme_example.py
@@ -1,0 +1,38 @@
+"""Execute the README example to guard against drift."""
+
+from __future__ import annotations
+
+import io
+import re
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+
+
+@pytest.mark.example
+@pytest.mark.timeout(30)
+def test_readme_usage_example() -> None:
+    """Run the README example and assert the expected output."""
+
+    readme = README_PATH.read_text(encoding="utf-8")
+
+    code_block: str | None = None
+    pattern = re.compile(r"```python\n(.*?)\n```", re.DOTALL)
+    for match in pattern.finditer(readme):
+        candidate = match.group(1)
+        if "RemoteOIDCTokenService" in candidate:
+            code_block = candidate
+            break
+
+    assert code_block, "Unable to locate README example"
+
+    stdout = io.StringIO()
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    with redirect_stdout(stdout):
+        exec(code_block, namespace)  # noqa: S102 - executing trusted documentation
+
+    output = stdout.getvalue()
+    assert "Verified subject: user-123" in output


### PR DESCRIPTION
## Summary
- expand the RemoteOIDC README with installation guidance, feature notes, and a runnable usage example aligned with the service implementation
- add a pytest that executes the README example to guard against documentation drift
- register the example pytest marker for the package

## Testing
- uv run --directory pkgs/standards/swarmauri_tokens_remoteoidc --package swarmauri_tokens_remoteoidc ruff format .
- uv run --directory pkgs/standards/swarmauri_tokens_remoteoidc --package swarmauri_tokens_remoteoidc ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_tokens_remoteoidc --package swarmauri_tokens_remoteoidc pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca779bd6bc83319327098c19a124fc