### PR TITLE
Align Doc2Vec README with implementation and add example test

### DIFF
--- a/pkgs/standards/swarmauri_embedding_doc2vec/README.md
+++ b/pkgs/standards/swarmauri_embedding_doc2vec/README.md
@@ -18,35 +18,54 @@
 
 # Swarmauri Embedding Doc2vec
 
-A Gensim-based Doc2Vec implementation for document embedding in the Swarmauri ecosystem. This package provides document vectorization capabilities using the Doc2Vec algorithm.
+A [Gensim](https://radimrehurek.com/gensim/)-powered Doc2Vec implementation for document
+embeddings in the Swarmauri ecosystem. The component registers as
+`Doc2VecEmbedding` and returns vectors as `swarmauri_standard.vectors.Vector`
+instances.
 
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_embedding_doc2vec
 ```
 
+```bash
+poetry add swarmauri_embedding_doc2vec
+```
+
+```bash
+uv pip install swarmauri_embedding_doc2vec
+```
+
 ## Usage
 
 ```python
-from swarmauri.embeddings.Doc2VecEmbedding import Doc2VecEmbedding
+from swarmauri_embedding_doc2vec import Doc2VecEmbedding
 
-# Initialize the embedder
-embedder = Doc2VecEmbedding(vector_size=3000)
+documents = [
+    "This is the first document.",
+    "Here is another document.",
+    "And a third one.",
+]
 
-# Prepare your documents
-documents = ["This is the first document.", "Here is another document.", "And a third one"]
+# Initialize the embedder. Adjust parameters to match your dataset size.
+embedder = Doc2VecEmbedding(vector_size=300, window=10, min_count=1, workers=1)
 
-# Fit and transform documents
+# Fit and transform documents into Vector objects.
 vectors = embedder.fit_transform(documents)
 
-# Transform new documents
-new_doc = "This is a new document"
-vector = embedder.transform([new_doc])
+# Access the raw embedding values via the Vector.value attribute.
+first_vector = vectors[0].value
 
-# Save and load the model
-embedder.save_model("doc2vec.model")
-embedder.load_model("doc2vec.model")
+# Transform new documents (the result is also a Vector).
+new_vector = embedder.transform(["This is a new document."])[0]
+
+# Save and load the underlying Doc2Vec model.
+model_path = "doc2vec.model"
+embedder.save_model(model_path)
+embedder.load_model(model_path)
 ```
 
 ## Want to help?

--- a/pkgs/standards/swarmauri_embedding_doc2vec/pyproject.toml
+++ b/pkgs/standards/swarmauri_embedding_doc2vec/pyproject.toml
@@ -37,6 +37,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example tests sourced from documentation",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_embedding_doc2vec/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_embedding_doc2vec/tests/test_readme_example.py
@@ -1,0 +1,55 @@
+"""Execute the README example to ensure it stays in sync with the package."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+
+_README_PATH: Final[Path] = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def _extract_readme_example() -> str:
+    content = _README_PATH.read_text(encoding="utf-8").splitlines()
+    in_block = False
+    code_lines: list[str] = []
+
+    for line in content:
+        stripped = line.strip()
+        if not in_block and stripped.startswith("```python"):
+            in_block = True
+            continue
+        if in_block and stripped.startswith("```"):
+            break
+        if in_block:
+            code_lines.append(line)
+
+    return "\n".join(code_lines)
+
+
+@pytest.mark.example
+def test_readme_example(tmp_path: Path) -> None:
+    code = _extract_readme_example()
+    assert code.strip(), "Expected a Python example code block in the README."
+
+    original_cwd = Path.cwd()
+    namespace: dict[str, object] = {}
+
+    try:
+        os.chdir(tmp_path)
+        exec(code, namespace)
+    finally:
+        os.chdir(original_cwd)
+
+    model_path = tmp_path / "doc2vec.model"
+    assert model_path.exists(), "The README example should persist the trained model."
+
+    vectors = namespace.get("vectors")
+    new_vector = namespace.get("new_vector")
+
+    assert isinstance(vectors, list) and len(vectors) == 3
+    assert all(hasattr(vec, "value") for vec in vectors)
+    assert new_vector is not None and hasattr(new_vector, "value")


### PR DESCRIPTION
## Summary
- update the Doc2Vec README to reflect the current import path, describe vector outputs, and include pip/poetry/uv installation commands
- register a pytest `example` marker and add a README-driven test that executes the documented usage

## Testing
- uv run --directory pkgs/standards/swarmauri_embedding_doc2vec --package swarmauri_embedding_doc2vec ruff format .
- uv run --directory pkgs/standards/swarmauri_embedding_doc2vec --package swarmauri_embedding_doc2vec ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_embedding_doc2vec --package swarmauri_embedding_doc2vec pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca77877a748331898b59b437cd6d80