### PR TITLE
Align Rust crypto README with behaviour

### DIFF
--- a/pkgs/standards/swarmauri_crypto_rust/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_rust/pyproject.toml
@@ -34,6 +34,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_crypto_rust/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_crypto_rust/tests/test_readme_example.py
@@ -1,0 +1,34 @@
+"""Tests that the README usage example remains executable."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parent.parent / "README.md"
+
+
+@pytest.mark.example
+def test_readme_usage_example_executes_successfully():
+    """Execute the README usage example and assert that it reports success."""
+
+    readme_contents = README_PATH.read_text(encoding="utf-8")
+    match = re.search(r"```python\n(.*?)\n```", readme_contents, re.DOTALL)
+    assert match, "Usage example code block not found in README.md"
+
+    code = match.group(1)
+    namespace: dict[str, object] = {
+        "__builtins__": __builtins__,
+        "__name__": "__main__",
+    }
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        exec(code, namespace)
+
+    output = stdout.getvalue()
+    assert "Match:     True" in output, output


### PR DESCRIPTION
## Summary
- align the Swarmauri Crypto Rust README with the behaviour exposed by the package and expand the installation section with pip, Poetry, and uv guidance
- add a pytest that executes the README usage example and make it easy to target via the `example` mark
- register the new example marker in the package configuration so the suite runs without warnings

## Testing
- uv run --directory pkgs/standards/swarmauri_crypto_rust --package swarmauri_crypto_rust ruff format .
- uv run --directory pkgs/standards/swarmauri_crypto_rust --package swarmauri_crypto_rust ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_crypto_rust --package swarmauri_crypto_rust pytest -m "not perf" -v

------
https://chatgpt.com/codex/tasks/task_b_68ca7781fff48331a5dca92472fd7914