### PR TITLE
Align InMemory key provider README and add example test

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
@@ -22,8 +22,19 @@ Volatile, in‑memory key provider for Swarmauri. All key material is kept stric
 
 ## Installation
 
+Install the package with your preferred Python tooling:
+
 ```bash
 pip install swarmauri_keyprovider_inmemory
+```
+
+```bash
+poetry add swarmauri_keyprovider_inmemory
+```
+
+```bash
+pip install uv
+uv pip install swarmauri_keyprovider_inmemory
 ```
 
 ## Usage
@@ -48,7 +59,7 @@ async def main() -> None:
     # Create a symmetric key kept only in memory
     spec = KeySpec(
         klass=KeyClass.symmetric,
-        alg=KeyAlg.AES256,                # optional hint – not strictly enforced
+        alg=KeyAlg.AES256_GCM,             # optional hint – not strictly enforced
         uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
         export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,  # material may be present
         label="session-key",

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/tests/example/test_readme_usage.py
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/tests/example/test_readme_usage.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import pytest
+
+from swarmauri_keyprovider_inmemory import InMemoryKeyProvider
+from swarmauri_core.crypto.types import ExportPolicy
+from swarmauri_core.keys.types import KeyAlg, KeyClass, KeySpec, KeyUse
+
+
+@pytest.mark.example
+def test_readme_usage_example() -> None:
+    async def main() -> None:
+        provider = InMemoryKeyProvider()
+
+        spec = KeySpec(
+            klass=KeyClass.symmetric,
+            alg=KeyAlg.AES256_GCM,
+            uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            label="session-key",
+        )
+        ref = await provider.create_key(spec)
+        assert ref.kid and ref.version == 1
+        assert ref.material is not None and len(ref.material) == 32
+
+        ref2 = await provider.rotate_key(ref.kid)
+        assert ref2.version == 2
+
+        versions = await provider.list_versions(ref.kid)
+        assert versions == (1, 2)
+
+        imported = await provider.import_key(
+            spec,
+            material=b"\x00" * 32,
+        )
+        assert imported.version == 1
+        if imported.material is not None:
+            assert imported.material == b"\x00" * 32
+
+        current = await provider.get_key(ref.kid)
+        assert current.version == max(versions)
+
+        assert await provider.destroy_key(ref.kid, version=1)
+        remaining = await provider.list_versions(ref.kid)
+        assert remaining == (2,)
+
+        assert await provider.destroy_key(imported.kid)
+
+        rand = await provider.random_bytes(16)
+        okm = await provider.hkdf(b"ikm", salt=b"salt", info=b"ctx", length=32)
+        assert len(rand) == 16
+        assert len(okm) == 32
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- expand the README installation section with poetry and uv commands and correct the usage example to use the AES256_GCM algorithm
- add a pytest marked as an example that executes the README scenario to keep the documentation and implementation aligned

## Testing
- uv run --directory pkgs/standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory ruff format .
- uv run --directory pkgs/standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca77dcb5dc8331bca334e98c5ff174