### PR TITLE
Document external imports evaluator and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_evaluator_externalimports/README.md
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/README.md
@@ -27,21 +27,111 @@ Evaluator that detects and penalizes non–standard-library imports in Python so
 
 ## Purpose
 
-This evaluator helps gauge dependency hygiene by examining import statements and flagging modules that are not part of the Python standard library.
+`ExternalImportsEvaluator` gauges dependency hygiene by walking the Python
+sources referenced by a [`swarmauri_core.programs.IProgram`](https://github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/core/swarmauri_core)
+and flagging modules that are not part of the Python standard library.
+
+## What it does
+
+1. Recursively walks every `.py` file beneath `program.path`.
+2. Parses each file's abstract syntax tree to collect `import` and
+   `from ... import ...` statements.
+3. Compares imported modules against the Python standard library (including
+   built-ins and a curated set of commonly used packages).
+4. Returns both a score and metadata describing any external dependencies that
+   were found.
+
+### How scoring works
+
+- The evaluator starts at a perfect score of **1.0**.
+- Each unique external module subtracts **0.1** from the score.
+- The score never drops below **0.0** regardless of how many modules are
+  flagged.
+
+### Metadata provided
+
+`evaluate` returns the score alongside a dictionary with:
+
+- `total_imports`: Count of all import statements encountered.
+- `external_imports_count`: Number of non-standard imports detected.
+- `unique_external_modules`: How many distinct external modules were used.
+- `external_modules`: A list of the external module names.
+- `external_imports_details`: Rich per-import entries containing the module,
+  alias, line number, import type, and whether the module was considered
+  standard.
+- `files_analyzed` and `python_files`: Insights into the scan coverage.
+- `execution_time`: Added by `EvaluatorBase` to show runtime of the analysis.
 
 ## Installation
 
+Pick the workflow that matches your toolchain:
+
 ```bash
+# pip
 pip install swarmauri_evaluator_externalimports
+
+# Poetry
+poetry add swarmauri_evaluator_externalimports
+
+# uv (install the tool if you have not already)
+curl -Ls https://astral.sh/uv/install.sh | sh
+uv add swarmauri_evaluator_externalimports
 ```
 
-## Usage
+## Example
+
+The snippet below creates a temporary project, evaluates it, and prints the
+results. You can drop it into a file such as `example.py` and run
+`python example.py`.
 
 ```python
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from swarmauri_core.programs.IProgram import IProgram
 from swarmauri_evaluator_externalimports import ExternalImportsEvaluator
 
-evaluator = ExternalImportsEvaluator()
-score, details = evaluator.evaluate(program)  # `program` is an instance of swarmauri_core.programs.IProgram
+
+class DirectoryProgram(IProgram):
+    """Minimal IProgram implementation backed by a filesystem path."""
+
+    def __init__(self, path: str):
+        self.path = path
+
+    def diff(self, other: "IProgram"):
+        raise NotImplementedError("Diffing is outside the scope of this example")
+
+    def apply_diff(self, diff: Any) -> "IProgram":
+        raise NotImplementedError("Diffing is outside the scope of this example")
+
+    def validate(self) -> bool:
+        return True
+
+    def clone(self) -> "IProgram":
+        return DirectoryProgram(self.path)
+
+
+def evaluate_example() -> tuple[float, dict[str, Any]]:
+    evaluator = ExternalImportsEvaluator()
+
+    with tempfile.TemporaryDirectory() as workdir:
+        project = Path(workdir)
+        project.joinpath("app.py").write_text(
+            """import os\nimport numpy\n\nprint(os.name, numpy.__version__)\n""",
+            encoding="utf-8",
+        )
+
+        program = DirectoryProgram(workdir)
+        score, details = evaluator.evaluate(program)
+
+        print("Score:", score)
+        print("External modules:", sorted(details["external_modules"]))
+        return score, details
+
+
+if __name__ == "__main__":
+    evaluate_example()
 ```
 
 ## Want to help?

--- a/pkgs/standards/swarmauri_evaluator_externalimports/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/tests/test_readme_example.py
@@ -1,0 +1,61 @@
+"""Execute the README example to ensure it remains accurate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parent.parent / "README.md"
+
+
+def _load_readme_example() -> str:
+    """Extract the first Python code block from the README."""
+
+    contents = README_PATH.read_text(encoding="utf-8")
+    lines = contents.splitlines()
+
+    code_lines = []
+    in_block = False
+
+    for line in lines:
+        if not in_block and line.strip().startswith("```python"):
+            in_block = True
+            continue
+
+        if in_block and line.strip().startswith("```"):
+            break
+
+        if in_block:
+            code_lines.append(line)
+
+    if not code_lines:
+        raise AssertionError("README example code block was not found")
+
+    return "\n".join(code_lines)
+
+
+@pytest.mark.example
+def test_readme_example_executes() -> None:
+    """Run the README usage example and assert the documented behaviour."""
+
+    namespace: Dict[str, Any] = {}
+    code = _load_readme_example()
+    exec(compile(code, str(README_PATH), "exec"), namespace)  # noqa: S102
+
+    evaluate_example = namespace.get("evaluate_example")
+    assert callable(evaluate_example), (
+        "README example should expose an `evaluate_example` function"
+    )
+
+    score, details = evaluate_example()
+
+    assert isinstance(score, float)
+    assert score == pytest.approx(0.9)
+
+    assert isinstance(details, dict)
+    assert set(details["external_modules"]) == {"numpy"}
+    assert details["external_imports_count"] == 1
+    assert details["unique_external_modules"] == 1


### PR DESCRIPTION
## Summary
- expand the README to describe how ExternalImportsEvaluator scores projects, what metadata it returns, and how to install it with pip, Poetry, or uv
- add a runnable example that evaluates a temporary project via a minimal IProgram implementation
- introduce a pytest marked with `@pytest.mark.example` that executes the README example to prevent it from drifting

## Testing
- `uv run --directory pkgs/standards --package swarmauri_evaluator_externalimports ruff format .`
- `uv run --directory pkgs/standards --package swarmauri_evaluator_externalimports ruff check . --fix`
- `uv run --directory pkgs/standards --package swarmauri_evaluator_externalimports pytest` *(fails: unrelated packages in the monorepo require optional dependencies such as cryptography and FastAPI)*

------
https://chatgpt.com/codex/tasks/task_b_68ca77b8ca2c8331a6a76e326a2453f6