### PR TITLE
Improve constant-time evaluator documentation and tests

### DIFF
--- a/pkgs/standards/swarmauri_evaluator_constanttime/README.md
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/README.md
@@ -22,12 +22,97 @@
 
 # Swarmauri Evaluator Constanttime
 
-Evaluator that detects timing side channels using a simple fixed-vs-random test.
+Evaluator that detects timing side channels using a fixed-vs-random strategy.
+It times a callable with repeated fixed inputs and compares those timings against
+randomly generated inputs. Welch's t-test and Cliff's delta are used to decide
+whether the observed runtime differences are statistically significant. The
+evaluator reports a score of `1.0` for constant-time behaviour and `0.0`
+otherwise, together with rich metadata about the underlying measurements.
 
 ## Installation
 
+### pip
+
 ```bash
 pip install swarmauri_evaluator_constanttime
+```
+
+### Poetry
+
+```bash
+poetry add swarmauri_evaluator_constanttime
+```
+
+### uv
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install swarmauri_evaluator_constanttime
+```
+
+## Usage
+
+The example below evaluates a deliberately leaky string comparison that sleeps
+for every matching byte. Fixed inputs run all the way through the comparison and
+take measurably longer than random guesses that fail fast, so the evaluator
+flags the function as *not* constant time.
+
+```python
+import secrets
+import time
+
+from swarmauri_core.programs.IProgram import IProgram
+from swarmauri_evaluator_constanttime import ConstantTimeEvaluator
+
+
+class DummyProgram(IProgram):
+    def diff(self, other: "IProgram"):
+        return ()
+
+    def apply_diff(self, diff):
+        return self
+
+    def validate(self) -> bool:
+        return True
+
+    def clone(self) -> "IProgram":
+        return DummyProgram()
+
+
+def insecure_compare(secret: bytes, guess: bytes) -> bool:
+    for secret_byte, guess_byte in zip(secret, guess):
+        if secret_byte != guess_byte:
+            return False
+        time.sleep(0.0001)
+    return len(secret) == len(guess)
+
+
+def make_input_pair() -> tuple[bytes, bytes]:
+    return secrets.token_bytes(16), secrets.token_bytes(16)
+
+
+def main() -> None:
+    evaluator = ConstantTimeEvaluator()
+    score, metadata = evaluator._compute_score(
+        program=DummyProgram(),
+        fn=insecure_compare,
+        make_input_pair=make_input_pair,
+        fixed_pair=(b"A" * 16, b"A" * 16),
+        n_samples=20,
+        iters_per=5,
+    )
+
+    print(f"Score: {score:.1f}")
+    print(f"Constant time? {metadata['constant_time']}")
+    print(f"t-statistic: {metadata['t_stat']:.2f}")
+    print(f"Cliff's delta: {metadata['cliff_delta']:.3f}")
+
+    assert metadata["constant_time"] is False
+
+
+if __name__ == "__main__":
+    main()
 ```
 
 ## Want to help?

--- a/pkgs/standards/swarmauri_evaluator_constanttime/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/pyproject.toml
@@ -48,6 +48,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Documentation-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_evaluator_constanttime/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/tests/test_readme_example.py
@@ -1,0 +1,29 @@
+"""Execute the README usage example to keep it working."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def _extract_usage_example() -> str:
+    text = README_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r"```python\n(?P<code>.*?ConstantTimeEvaluator.*?)```", re.DOTALL
+    )
+    match = pattern.search(text)
+    if not match:  # pragma: no cover - defensive guard to show clearer error
+        raise AssertionError("Could not locate the README usage example.")
+    return match.group("code").strip()
+
+
+@pytest.mark.example
+def test_readme_usage_example() -> None:
+    code = _extract_usage_example()
+    namespace = {"__name__": "__main__"}
+    exec(compile(code, str(README_PATH), "exec"), namespace)  # noqa: S102


### PR DESCRIPTION
## Summary
- expand the README with additional installation guidance and a runnable constant-time detection example
- register the example pytest marker and add a test that executes the README usage snippet

## Testing
- uv run --directory pkgs/standards --package swarmauri_evaluator_constanttime pytest swarmauri_evaluator_constanttime/tests

------
https://chatgpt.com/codex/tasks/task_b_68ca77b80da483319c4740a70fa5a8d2