### PR TITLE
Update swarmauri_tokens_jwt README to reflect service behavior

### DIFF
--- a/pkgs/standards/swarmauri_tokens_jwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_jwt/README.md
@@ -24,22 +24,37 @@ endpoint for public key discovery.
 
 ## Installation
 
+Install the service with your preferred Python packaging tool:
+
 ```bash
 pip install swarmauri_tokens_jwt
 ```
 
+```bash
+poetry add swarmauri_tokens_jwt
+```
+
+```bash
+uv pip install swarmauri_tokens_jwt
+```
+
 ## Features
 
-- Mint and verify JWS/JWT tokens
+- Mint and verify JWS/JWT tokens backed by any :class:`~swarmauri_core.keys.IKeyProvider`
 - Supports algorithms like **HS256**, **RS256**, **ES256**, **PS256** and **EdDSA**
-- Integrates with any :class:`~swarmauri_core.keys.IKeyProvider`
-- Publishes a JWKS endpoint for public key discovery
+- Adds standard temporal claims (`iat`, `nbf`, and optional `exp`) plus issuer,
+  subject, audience and scope defaults when minting tokens
+- Validates expiration, not-before, issuer and audience claims during
+  verification
+- Publishes a JWKS endpoint for public key discovery through your key provider
+- Install the optional ``cryptography`` dependency to enable RSA, ECDSA and
+  EdDSA signing keys
 
 ## Usage
 
-`JWTTokenService` requires an `IKeyProvider` to supply signing material. The
-example below shows how to mint and verify a symmetric **HS256** token using a
-minimal in‑memory key provider.
+`JWTTokenService` requires an asynchronous `IKeyProvider` to supply signing
+material. The example below shows how to mint and verify a symmetric **HS256**
+token using a minimal in-memory key provider.
 
 ```python
 import asyncio
@@ -105,13 +120,23 @@ class InMemoryKeyProvider(IKeyProvider):
 
 async def main() -> None:
     svc = JWTTokenService(InMemoryKeyProvider(), default_issuer="issuer")
-    token = await svc.mint({"sub": "alice"}, alg=JWAAlg.HS256, kid="sym")
+    token = await svc.mint(
+        {"sub": "alice"},
+        alg=JWAAlg.HS256,
+        kid="sym",
+        lifetime_s=600,  # override the default one-hour lifetime if needed
+    )
     claims = await svc.verify(token, issuer="issuer")
     assert claims["sub"] == "alice"
 
 
 asyncio.run(main())
 ```
+
+`verify` retrieves the JSON Web Key Set from the provider and enforces
+expiration, not-before, issuer and audience checks before returning the decoded
+claims. Expose the service's :meth:`jwks` coroutine to publish the active public
+keys from your provider.
 
 The service also supports asymmetric algorithms such as **RS256**, **ES256** and
 **EdDSA** when the key provider exposes the appropriate keys. See the


### PR DESCRIPTION
## Summary
- document pip, Poetry, and uv installation workflows for `swarmauri_tokens_jwt`
- clarify README features and usage details to match `JWTTokenService` defaults and verification behavior

## Testing
- `uv run --directory pkgs/standards/swarmauri_tokens_jwt --package swarmauri_tokens_jwt ruff format .`
- `uv run --directory pkgs/standards/swarmauri_tokens_jwt --package swarmauri_tokens_jwt ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_b_68ca77a104748331ae8dace8ba647dae