### PR TITLE
Align CompositeCrypto README with behavior and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_crypto_composite/README.md
+++ b/pkgs/standards/swarmauri_crypto_composite/README.md
@@ -17,20 +17,103 @@
 
 ## Swarmauri Crypto Composite
 
-Algorithm-routing crypto provider delegating to child providers based on requested algorithms.
+`CompositeCrypto` is an algorithm-routing crypto provider that delegates encryption
+operations to the first child provider that advertises support for the requested
+algorithm. Its behaviour is defined entirely by the wrapped providers:
+
+- Aggregates each provider's `supports()` capabilities and removes duplicates.
+- Normalises requested algorithms before routing so stylistic variants still match.
+- Requires at least one child provider to be supplied at construction time.
+- Exposes the full asynchronous `ICrypto` surface area (encrypt, wrap, seal, etc.).
 
 ## Installation
+
+Choose the tool that best fits your workflow:
 
 ```bash
 pip install swarmauri_crypto_composite
 ```
 
+```bash
+poetry add swarmauri_crypto_composite
+```
+
+```bash
+uv add swarmauri_crypto_composite
+```
+
 ## Usage
 
 ```python
-from swarmauri_crypto_composite import CompositeCrypto
+"""Route crypto operations to the provider that supports the requested algorithm."""
+import asyncio
 
-crypto = CompositeCrypto([...])  # pass in other ICrypto providers
+from swarmauri_crypto_composite import CompositeCrypto
+from swarmauri_core.crypto.ICrypto import ICrypto
+from swarmauri_core.crypto.types import (
+    AEADCiphertext,
+    ExportPolicy,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+
+
+class DummyCrypto(ICrypto):
+    def __init__(self, name: str, alg: str) -> None:
+        self._name = name
+        self._alg = alg
+
+    def supports(self):
+        return {"encrypt": (self._alg,)}
+
+    async def encrypt(self, key, pt, *, alg=None, aad=None, nonce=None):
+        return AEADCiphertext(
+            kid="dummy",
+            version=1,
+            alg=alg or self._alg,
+            nonce=b"",
+            ct=self._name.encode(),
+            tag=b"",
+        )
+
+    async def decrypt(self, key, ct, *, aad=None):  # pragma: no cover - demo only
+        raise NotImplementedError
+
+    async def wrap(self, kek, *, dek=None, wrap_alg=None, nonce=None):  # pragma: no cover - demo only
+        raise NotImplementedError
+
+    async def unwrap(self, kek, wrapped):  # pragma: no cover - demo only
+        raise NotImplementedError
+
+    async def seal(self, recipient, pt, *, alg=None):  # pragma: no cover - demo only
+        raise NotImplementedError
+
+    async def unseal(self, recipient_priv, sealed, *, alg=None):  # pragma: no cover - demo only
+        raise NotImplementedError
+
+
+async def main() -> None:
+    # Compose two providers that advertise different algorithms.
+    chacha = DummyCrypto("chacha", "CHACHA20-POLY1305")
+    aes = DummyCrypto("aes", "A256GCM")
+    composite = CompositeCrypto([chacha, aes])
+
+    key = KeyRef(
+        kid="k",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=b"\x00" * 32,
+    )
+
+    ciphertext = await composite.encrypt(key, b"payload", alg="A256GCM")
+    print(f"Selected provider: {ciphertext.ct.decode()}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Entry point

--- a/pkgs/standards/swarmauri_crypto_composite/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_composite/pyproject.toml
@@ -35,6 +35,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: README-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_crypto_composite/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_crypto_composite/tests/test_readme_example.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def _extract_example_block() -> str:
+    text = README.read_text(encoding="utf-8")
+    pattern = re.compile(r"```python\n(.*?)\n```", re.DOTALL)
+    for match in pattern.finditer(text):
+        block = match.group(1)
+        if "CompositeCrypto" in block and "asyncio.run" in block:
+            return block
+    raise AssertionError("Unable to find README example block")
+
+
+@pytest.mark.example
+def test_readme_example_executes(capsys):
+    code = _extract_example_block()
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(compile(code, str(README), "exec"), namespace)
+    captured = capsys.readouterr()
+    assert "Selected provider: aes" in captured.out


### PR DESCRIPTION
## Summary
- expand the CompositeCrypto README to describe its routing behaviour and add pip/poetry/uv installation commands
- provide an executable async usage example that demonstrates provider selection
- register an `example` pytest mark and add a README-backed test that runs the documented example

## Testing
- uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca775ea5008331bcb74e0bc09c287b