### PR TITLE
docs: add README example coverage for ecdh a128kw crypto

### DIFF
--- a/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/README.md
+++ b/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/README.md
@@ -20,7 +20,89 @@
 
 ECDH-ES+A128KW key wrapping provider for Swarmauri.
 
-This plugin implements key wrapping and unwrapping using the
-ECDH-ES key agreement scheme combined with AES Key Wrap using a
-128-bit key. It exposes the `ECDHESA128KWCrypto` class which
-conforms to the `ICrypto` contract.
+## Highlights
+
+- Implements the JSON Web Encryption ECDH-ES key agreement combined with AES Key Wrap using a 128-bit KEK (`ECDH-ES+A128KW`).
+- Accepts `KeyRef` objects whose `public` attribute carries an EC public key in PEM format for wrapping and whose `material` attribute provides the corresponding private key for unwrapping.
+- Derives a one-time key-encryption key via Concat KDF with SHA-256 and serializes results as JSON containing the ephemeral public key (`epk`) and wrapped DEK (`kw`), both Base64URL encoded.
+- Generates a fresh 16-byte DEK when one is not provided so you can delegate symmetric key generation to the provider.
+
+## Installation
+
+Choose the tool that matches your workflow:
+
+```bash
+# pip
+pip install swarmauri_crypto_ecdh_es_a128kw
+
+# Poetry
+poetry add swarmauri_crypto_ecdh_es_a128kw
+
+# uv
+uv add swarmauri_crypto_ecdh_es_a128kw
+```
+
+## Quickstart
+
+The example below creates a recipient EC key pair, wraps a deterministic 128-bit DEK, and then unwraps it again to demonstrate the round trip. Run it with `python quickstart.py` or paste it into a REPL.
+
+```python
+import asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+from swarmauri_crypto_ecdh_es_a128kw import ECDHESA128KWCrypto
+
+
+def make_recipient_key() -> KeyRef:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    public_key = private_key.public_key()
+
+    return KeyRef(
+        kid="recipient-key",
+        version=1,
+        type=KeyType.EC,
+        uses=(KeyUse.WRAP, KeyUse.UNWRAP),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        public=public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ),
+    )
+
+
+async def main() -> None:
+    crypto = ECDHESA128KWCrypto()
+    recipient = make_recipient_key()
+    dek = b"0123456789ABCDEF"  # 16 byte content encryption key
+
+    wrapped = await crypto.wrap(recipient, dek=dek)
+    recovered = await crypto.unwrap(recipient, wrapped)
+
+    print("Wrapped payload:", wrapped.wrapped.decode("utf-8"))
+    assert recovered == dek
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### What to expect
+
+- `wrap` derives an ephemeral ECDH shared secret with the recipient public key, hashes it with Concat KDF (SHA-256) to produce a 128-bit KEK, and AES-KW wraps the provided DEK.
+- The returned `WrappedKey` stores a JSON document containing the ephemeral public key (`epk`) and the wrapped DEK (`kw`), both Base64URL encoded.
+- `unwrap` repeats the derivation using the recipient private key (`KeyRef.material`) and returns the original DEK bytes.
+
+## License
+
+`swarmauri_crypto_ecdh_es_a128kw` is licensed under the Apache License 2.0. See the [LICENSE](https://github.com/swarmauri/swarmauri-sdk/blob/master/LICENSE) file for details.
+
+## Entry point
+
+The provider is registered under the `swarmauri.cryptos` entry point as `ECDHESA128KWCrypto`.

--- a/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/pyproject.toml
@@ -36,6 +36,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/tests/test_readme_example.py
@@ -1,0 +1,20 @@
+import re
+from pathlib import Path
+
+import pytest
+
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+@pytest.mark.example
+def test_quickstart_example_executes() -> None:
+    """Execute the README quickstart example to ensure it stays valid."""
+    contents = README.read_text(encoding="utf-8")
+    match = re.search(r"```python\n(.*?)\n```", contents, re.DOTALL)
+    if match is None:
+        pytest.fail("Could not locate python example in README.md")
+
+    code = match.group(1)
+    namespace: dict[str, object] = {"__name__": "__main__"}
+    exec(compile(code, str(README), "exec"), namespace)


### PR DESCRIPTION
## Summary
- expand the ECDH-ES+A128KW README with installation guidance, feature highlights, and a runnable quickstart example
- add a pytest that executes the README quickstart to keep the documentation honest and mark it as an example
- register the new pytest marker in the package configuration

## Testing
- uv run --directory pkgs/standards/swarmauri_crypto_ecdh_es_a128kw --package swarmauri_crypto_ecdh_es_a128kw pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca775fdac48331963c34ba53dcfd38