### PR TITLE
Update PGP README and add README example test

### DIFF
--- a/pkgs/standards/swarmauri_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_crypto_pgp/README.md
@@ -17,46 +17,96 @@
 
 ## Swarmauri Crypto PGP
 
-OpenPGP (GnuPG-backed) crypto provider implementing the `ICrypto` contract.
+`PGPCrypto` is an OpenPGP (GnuPG-backed) crypto provider that implements the
+`ICrypto` contract from `swarmauri_core`. It combines modern AEAD primitives
+with OpenPGP public-key operations so that the same component can handle
+symmetrical encryption, public-key key wrapping, and hybrid envelopes.
 
-- Symmetric AEAD: AES-256-GCM
-- Key wrapping: OpenPGP public-key encryption (RSA keys recommended)
-- Hybrid encrypt-for-many supported
+### Features at a glance
+
+- **Symmetric AEAD** – AES-256-GCM powers `encrypt` and `decrypt`.
+- **Key wrapping** – `wrap` and `unwrap` delegate to GnuPG to protect random or
+  supplied key material with a recipient's public/private key pair.
+- **Hybrid envelopes** – `encrypt_for_many` supports both traditional
+  KEM+AEAD (shared ciphertext + wrapped session key) and OpenPGP sealed mode for
+  per-recipient ciphertexts.
+- **Sealing convenience** – `seal` and `unseal` provide single-recipient
+  OpenPGP public-key encryption without managing the envelope structure.
+
+### System requirements
+
+- Python 3.10 – 3.13.
+- [GnuPG](https://gnupg.org/) available on the `PATH` (required by
+  `python-gnupg`).
 
 ### Key material expectations
 
-- `encrypt`/`decrypt`: `KeyRef.material` must be 16/24/32 bytes for AES-GCM
-- `wrap`/`encrypt_for_many`: `KeyRef.public` must be ASCII-armored OpenPGP public key bytes
-- `unwrap`: `KeyRef.material` must be ASCII-armored OpenPGP private key bytes
+- `encrypt` / `decrypt`: `KeyRef.material` must be 16/24/32 bytes for AES-GCM.
+- `wrap` / `encrypt_for_many`: `KeyRef.public` must be ASCII-armored OpenPGP
+  public key bytes.
+- `unwrap` / `unseal`: `KeyRef.material` must be ASCII-armored OpenPGP private
+  key bytes. Supply a passphrase via `KeyRef.tags["passphrase"]` when needed.
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_crypto_pgp
+
+# Poetry
+poetry add swarmauri_crypto_pgp
+
+# uv
+uv add swarmauri_crypto_pgp
 ```
 
-## Usage
+## Quickstart
+
+The snippet below mirrors the asynchronous usage exercised in the tests. It
+creates a symmetric `KeyRef`, encrypts plaintext, and decrypts the resulting
+`AEADCiphertext` back to bytes.
 
 ```python
+import asyncio
+
 from swarmauri_crypto_pgp import PGPCrypto
-from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
 
-crypto = PGPCrypto()
 
-# Symmetric key for AEAD
-sym = KeyRef(
-    kid="sym1",
-    version=1,
-    type=KeyType.SYMMETRIC,
-    uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
-    export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
-    material=b"\x00" * 32,
-)
+async def main() -> None:
+    crypto = PGPCrypto()
 
-ct = await crypto.encrypt(sym, b"hello")
-pt = await crypto.decrypt(sym, ct)
+    # Symmetric key for AES-256-GCM
+    sym = KeyRef(
+        kid="sym1",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=b"\x00" * 32,
+    )
+
+    ct = await crypto.encrypt(sym, b"hello OpenPGP")
+    pt = await crypto.decrypt(sym, ct)
+
+    print(pt)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
+
+### Working with recipients
+
+- Call `encrypt_for_many` with recipient public keys to either produce an
+  AES-GCM ciphertext with OpenPGP-wrapped session keys (default) or
+  per-recipient sealed blobs by passing `enc_alg="OpenPGP-SEAL"`.
+- Use `seal` / `unseal` for single-recipient OpenPGP public-key encryption.
+- `wrap` and `unwrap` offer direct access to OpenPGP-based key encapsulation.
 
 ## Entry point
 
-The provider is registered under the `swarmauri.cryptos` entry-point as `PGPCrypto`.
+The provider is registered under the `swarmauri.cryptos` entry-point as
+`PGPCrypto`.

--- a/pkgs/standards/swarmauri_crypto_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_pgp/pyproject.toml
@@ -37,6 +37,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_crypto_pgp/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_crypto_pgp/tests/example/test_readme_example.py
@@ -1,0 +1,24 @@
+import pytest
+
+from swarmauri_crypto_pgp import PGPCrypto
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+
+
+@pytest.mark.asyncio
+@pytest.mark.example
+async def test_readme_quickstart_example() -> None:
+    crypto = PGPCrypto()
+
+    sym = KeyRef(
+        kid="sym1",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=b"\x00" * 32,
+    )
+
+    ct = await crypto.encrypt(sym, b"hello OpenPGP")
+    pt = await crypto.decrypt(sym, ct)
+
+    assert pt == b"hello OpenPGP"


### PR DESCRIPTION
## Summary
- align the README with the provider capabilities, add pip/Poetry/uv installation guidance, and document an async quickstart example
- register the `example` pytest marker used for documentation-driven tests
- add a README-backed pytest that exercises the quickstart snippet to guard the documentation example

## Testing
- uv run --directory pkgs/standards/swarmauri_crypto_pgp --package swarmauri_crypto_pgp ruff format .
- uv run --directory pkgs/standards/swarmauri_crypto_pgp --package swarmauri_crypto_pgp ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_crypto_pgp --package swarmauri_crypto_pgp pytest


------
https://chatgpt.com/codex/tasks/task_b_68ca7775311c8331983b45c92c207bee