### PR TITLE
Update NaCl PKCS#11 README and add example test

### DIFF
--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
@@ -17,39 +17,67 @@
 
 ## Swarmauri Crypto NaCl PKCS#11
 
-Hybrid crypto provider using PyNaCl for Ed25519/X25519 operations and `python-pkcs11` for AES-KW key wrapping. Implements the `ICrypto` contract via `CryptoBase`.
+`swarmauri_crypto_nacl_pkcs11` is a hybrid crypto provider that combines [PyNaCl](https://pynacl.readthedocs.io) for X25519 sealed-box operations with [`python-pkcs11`](https://python-pkcs11.readthedocs.io) for AES key wrapping. The provider implements the `CryptoBase` contract and is discoverable via the `swarmauri.cryptos` entry-point as `NaClPkcs11Crypto`.
 
-- AES-GCM symmetric encrypt/decrypt
-- AES-KW wrap/unwrap using PKCS#11
-- X25519 sealed boxes for single and multi-recipient encryption
+### Supported operations
+
+- **AES-GCM authenticated encryption** via `encrypt`/`decrypt` using symmetric `KeyRef` material that is exactly 16, 24, or 32 bytes long.
+- **AES Key Wrap (AES-KW)** via `wrap`/`unwrap` against an HSM-protected key. The PKCS#11 session is resolved from the `KeyRef.tags` (`module`, `slot_label`, `user_pin`, `label`) or the environment variables `PKCS11_MODULE`, `PKCS11_SLOT_LABEL`, `PKCS11_USER_PIN`, and `PKCS11_KEK_LABEL`.
+- **X25519 sealed boxes** via `seal`/`unseal` and `encrypt_for_many`, enabling single or multi-recipient payload distribution. When additional authenticated data (AAD) is supplied the envelope is rebound with AES-GCM before delivery.
 
 ## Installation
+
+Choose the workflow that matches your project:
 
 ```bash
 pip install swarmauri_crypto_nacl_pkcs11
 ```
 
-## Usage
-
-```python
-from swarmauri_crypto_nacl_pkcs11 import NaClPkcs11Crypto
-from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
-
-crypto = NaClPkcs11Crypto()
-
-sym = KeyRef(
-    kid="sym1",
-    version=1,
-    type=KeyType.SYMMETRIC,
-    uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
-    export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
-    material=b"\x00" * 32,
-)
-
-ct = await crypto.encrypt(sym, b"hello")
-pt = await crypto.decrypt(sym, ct)
+```bash
+poetry add swarmauri_crypto_nacl_pkcs11
 ```
 
-## Entry point
+```bash
+uv add swarmauri_crypto_nacl_pkcs11
+```
 
-The provider is registered under the `swarmauri.cryptos` entry-point as `NaClPkcs11Crypto`.
+## Usage
+
+All cryptographic methods are asynchronous. The quick-start example below performs an AES-GCM round trip using a 256-bit symmetric key.
+
+<!-- example-start -->
+```python
+import asyncio
+
+from swarmauri_crypto_nacl_pkcs11 import NaClPkcs11Crypto
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+
+
+async def main() -> None:
+    crypto = NaClPkcs11Crypto()
+
+    symmetric_key = KeyRef(
+        kid="sym1",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=b"\x00" * 32,
+    )
+
+    ciphertext = await crypto.encrypt(symmetric_key, b"hello")
+    plaintext = await crypto.decrypt(symmetric_key, ciphertext)
+    assert plaintext == b"hello"
+
+
+asyncio.run(main())
+```
+<!-- example-end -->
+
+### Sealed box key exchange
+
+`seal` and `encrypt_for_many` expect X25519 `KeyRef` instances. Provide the public key bytes via `KeyRef.public` for recipients and the private key bytes via `KeyRef.material` for unsealing. Each recipient receives an opaque sealed payload generated with `nacl.public.SealedBox`.
+
+### PKCS#11-backed key wrapping
+
+`wrap` and `unwrap` require a key-encryption-key (KEK) stored in the configured PKCS#11 slot. Supply connection details through `KeyRef.tags` or environment variables as described above. The wrapped material is returned as a `WrappedKey` using the `AES-KW` algorithm.

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/pyproject.toml
@@ -38,6 +38,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: README backed examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/tests/test_readme.py
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/tests/test_readme.py
@@ -1,0 +1,36 @@
+"""Ensure the README example continues to run successfully."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parent.parent / "README.md"
+EXAMPLE_START = "<!-- example-start -->"
+EXAMPLE_END = "<!-- example-end -->"
+
+
+def _extract_readme_example() -> str:
+    text = README_PATH.read_text(encoding="utf-8")
+
+    try:
+        start = text.index(EXAMPLE_START) + len(EXAMPLE_START)
+        end = text.index(EXAMPLE_END, start)
+    except ValueError as exc:  # pragma: no cover - signals README drift
+        raise AssertionError("README example markers are missing") from exc
+
+    fenced = text[start:end]
+    fence_start = fenced.index("```") + 3
+    fence_end = fenced.rindex("```")
+    code = fenced[fence_start:fence_end].lstrip()
+    if code.startswith("python"):
+        code = code[len("python") :].lstrip("\n")
+    return code
+
+
+@pytest.mark.example
+def test_readme_example_executes() -> None:
+    example = _extract_readme_example()
+    exec(compile(example, str(README_PATH), "exec"), {})


### PR DESCRIPTION
## Summary
- align the README with the package’s supported algorithms and configuration expectations
- document pip, poetry, and uv installation flows and refresh the asynchronous quick-start example
- add a README-backed pytest that executes the documented example and register the custom mark

## Testing
- uv run --directory pkgs/standards/swarmauri_crypto_nacl_pkcs11 --package swarmauri_crypto_nacl_pkcs11 pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca777286188331bd0dcc9410b775b2