### PR TITLE
docs: expand paramiko crypto usage guidance

### DIFF
--- a/pkgs/standards/swarmauri_crypto_paramiko/README.md
+++ b/pkgs/standards/swarmauri_crypto_paramiko/README.md
@@ -20,23 +20,36 @@
 Paramiko-backed crypto provider implementing the `ICrypto` contract via
 `CryptoBase`. Built on top of [`paramiko`](https://www.paramiko.org/) and
 [`cryptography`](https://cryptography.io/), it exposes an asynchronous API for
-several cryptographic primitives.
+several cryptographic primitives using OpenSSH-formatted public keys and
+PEM-encoded private keys supplied through `KeyRef` objects.
 
 ### Features
 
-- AES-256-GCM symmetric encrypt/decrypt
-- RSA-OAEP(SHA-256) wrap/unwrap
+- AES-256-GCM symmetric encrypt/decrypt (16/24/32 byte keys)
+- RSA-OAEP(SHA-256) wrap/unwrap for OpenSSH RSA key pairs
+- AES-256-GCM key wrap/unwrap when the KEK is symmetric
 - RSA-OAEP(SHA-256) sealing for small payloads
 - Multi-recipient hybrid envelopes using OpenSSH public keys
 
 Keys are represented by `KeyRef` objects. Public keys should be provided in
 OpenSSH format via `KeyRef.public`, while private keys are supplied as
-PEM-encoded bytes in `KeyRef.material`.
+PEM-encoded bytes in `KeyRef.material`. RSA sealing is limited to inputs no
+larger than the modulus-dependent RSA-OAEP bound (`modulus_bytes - 2 * hash_len
+- 2`). For larger payloads use the hybrid envelope mode instead.
 
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_crypto_paramiko
+
+# Poetry
+poetry add swarmauri_crypto_paramiko
+
+# uv
+uv add swarmauri_crypto_paramiko
 ```
 
 ## Usage
@@ -93,6 +106,23 @@ wrapped = await crypto.wrap(recipient)
 unwrapped = await crypto.unwrap(recipient, wrapped)
 ```
 
+To wrap with a symmetric key-encryption key instead, provide the AES key bytes
+in `KeyRef.material` and set `wrap_alg="AES-256-GCM"`:
+
+```python
+sym_kek = KeyRef(
+    kid="kek1",
+    version=1,
+    type=KeyType.SYMMETRIC,
+    uses=(KeyUse.WRAP, KeyUse.UNWRAP),
+    export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    material=b"\x01" * 32,
+)
+
+wrapped = await crypto.wrap(sym_kek, wrap_alg="AES-256-GCM")
+plaintext_key = await crypto.unwrap(sym_kek, wrapped)
+```
+
 ### RSA Sealing for Small Payloads
 
 ```python
@@ -106,6 +136,12 @@ plaintext = await crypto.unseal(recipient, sealed)
 ```python
 env = await crypto.encrypt_for_many([recipient], b"secret")
 ```
+
+Calling `encrypt_for_many` without overrides produces an AES-256-GCM ciphertext
+shared by every recipient, while `env.recipients` holds RSA-OAEP-wrapped
+session keys. Use `enc_alg="RSA-OAEP-SHA256-SEAL"` to emit individual RSA-OAEP
+sealed payloads instead of a shared ciphertext when the plaintext fits within
+the sealing size limit.
 
 ## Entry point
 


### PR DESCRIPTION
## Summary
- clarify how ParamikoCrypto maps `KeyRef` data to supported algorithms
- document AES-256-GCM key wrapping, sealing limits, and multi-recipient envelope behavior
- add Poetry and uv installation commands alongside pip guidance

## Testing
- uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko ruff format .
- uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko ruff check . --fix

------
https://chatgpt.com/codex/tasks/task_b_68ca777744d08331a1779a3cbaa044f1