### PR TITLE
Align Minkowski README with implementation and test example

### DIFF
--- a/pkgs/standards/swarmauri_distance_minkowski/README.md
+++ b/pkgs/standards/swarmauri_distance_minkowski/README.md
@@ -18,19 +18,44 @@
 
 # Swarmauri Distance Minkowski
 
-A Python package implementing Minkowski distance metric for vector comparison. This distance metric is a generalization that includes both Euclidean and Manhattan distances.
+A Python package implementing the Minkowski distance metric for vector
+comparison within the Swarmauri ecosystem.  The metric generalizes common
+distances such as Euclidean (`p = 2`) and Manhattan (`p = 1`).
+
+The distribution issues a `DeprecationWarning` announcing removal in
+`v0.10.0`.  Consume the distance through Swarmauri's plugin interfaces or
+switch to an alternative implementation before that release.
+
+## Features
+
+- Computes Minkowski distance between vectors using `scipy.spatial.distance`.
+- Enforces matching vector dimensionality and raises `ValueError` when shapes
+  differ.
+- Offers a tunable `p` value along with batch helpers (`distances`,
+  `similarities`).
+- Derives a similarity score from distance as `1 / (1 + distance)`.
 
 ## Installation
+
+Install the package with your preferred Python packaging tool:
 
 ```bash
 pip install swarmauri_distance_minkowski
 ```
 
+```bash
+poetry add swarmauri_distance_minkowski
+```
+
+```bash
+uv pip install swarmauri_distance_minkowski
+```
+
 ## Usage
 
 ```python
-from swarmauri.distances.MinkowskiDistance import MinkowskiDistance
-from swarmauri.vectors.Vector import Vector
+from swarmauri_distance_minkowski import MinkowskiDistance
+from swarmauri_standard.vectors.Vector import Vector
 
 # Create vectors for comparison
 vector_a = Vector(value=[1, 2])
@@ -41,12 +66,22 @@ distance_calculator = MinkowskiDistance()
 
 # Calculate distance between vectors
 distance = distance_calculator.distance(vector_a, vector_b)
-print(f"Distance: {distance}")  # Output: Distance: 0.0
+print(f"Distance: {distance}")
 
 # Calculate similarity between vectors
 similarity = distance_calculator.similarity(vector_a, vector_b)
-print(f"Similarity: {similarity}")  # Output: Similarity: 1.0
+print(f"Similarity: {similarity}")
 ```
+
+Running the example prints:
+
+```
+Distance: 0.0
+Similarity: 1.0
+```
+
+Customize the `p` value to select different Minkowski norms, or supply a
+sequence of vectors to `distances` / `similarities` for batch comparisons.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_distance_minkowski/pyproject.toml
+++ b/pkgs/standards/swarmauri_distance_minkowski/pyproject.toml
@@ -29,6 +29,7 @@ swarmauri_standard = { workspace = true }
 norecursedirs = ["combined", "scripts"]
 markers = [
     "test: standard test",
+    "example: Documentation examples",
     "unit: Unit tests",
     "i9n: Integration tests",
     "r8n: Regression tests",

--- a/pkgs/standards/swarmauri_distance_minkowski/tests/test_readme_example.py
+++ b/pkgs/standards/swarmauri_distance_minkowski/tests/test_readme_example.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _extract_first_python_code_block(text: str) -> str:
+    lines = text.splitlines()
+    code_lines: list[str] = []
+    in_block = False
+
+    for line in lines:
+        stripped = line.strip()
+        if not in_block:
+            if stripped == "```python":
+                in_block = True
+            continue
+
+        if stripped == "```":
+            break
+
+        code_lines.append(line)
+
+    return "\n".join(code_lines)
+
+
+@pytest.mark.example
+def test_readme_example_executes() -> None:
+    readme_path = Path(__file__).resolve().parent.parent / "README.md"
+    code_block = _extract_first_python_code_block(
+        readme_path.read_text(encoding="utf-8")
+    )
+
+    assert code_block, "README.md must contain a Python example code block"
+
+    namespace: dict[str, object] = {}
+    exec(code_block, namespace)
+
+    assert namespace["distance"] == 0.0
+    assert namespace["similarity"] == 1.0


### PR DESCRIPTION
## Summary
- refresh the Minkowski distance README to describe the actual behaviour, note the deprecation warning, and add pip/poetry/uv installation guidance with an accurate usage example
- register a pytest `example` marker and add a README-backed test that executes the documented example to keep it in sync

## Testing
- uv run --directory pkgs/standards/swarmauri_distance_minkowski --package swarmauri_distance_minkowski pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca7786e3f48331bbd0f03a6a3b65d9