### PR TITLE
Update self-signed cert README with runnable quickstart example

### DIFF
--- a/pkgs/standards/swarmauri_certs_self_signed/README.md
+++ b/pkgs/standards/swarmauri_certs_self_signed/README.md
@@ -20,12 +20,71 @@
 
 Standalone plugin providing utilities to issue self-signed X.509 certificates using the `SelfSignedCertificate` builder.
 
+## Features
+
+- Issue PEM (default) or DER encoded self-signed certificates from existing private keys.
+- Populate subjects, subject alternative names, name constraints, and key usage extensions via simple dictionaries.
+- Convenience constructors for common TLS server and mTLS client certificates.
+- Automatically reuse a passphrase stored in `KeyRef.tags["passphrase"]` when loading encrypted keys.
+
 ## Installation
 
+Choose the tool that matches your workflow:
+
 ```bash
+# pip
 pip install swarmauri_certs_self_signed
+
+# Poetry
+poetry add swarmauri_certs_self_signed
+
+# uv
+uv add swarmauri_certs_self_signed
 ```
+
+## Quickstart
+
+`SelfSignedCertificate` operates on a `KeyRef` whose `material` holds the PEM encoded private key. The example below generates an Ed25519 key, issues a TLS server certificate with DNS subject alternative names, and prints the PEM header of the resulting certificate.
+
+```python
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+from swarmauri_certs_self_signed import SelfSignedCertificate
+
+private_key = ed25519.Ed25519PrivateKey.generate()
+private_bytes = private_key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+)
+
+key_ref = KeyRef(
+    kid="example-ed25519",
+    version=1,
+    type=KeyType.ED25519,
+    uses=(KeyUse.SIGN,),
+    export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    material=private_bytes,
+)
+
+builder = SelfSignedCertificate.tls_server(
+    common_name="example.local",
+    dns_names=["example.local", "api.example.local"],
+)
+
+certificate_pem = builder.issue(key_ref)
+print(certificate_pem.decode().splitlines()[0])
+```
+
+The builder automatically mirrors the TLS server defaults: the subject common name is set from `common_name`, all DNS names are added to the SAN extension, and the certificate is valid for 397 days unless overridden. Set `output_der=True` on the builder to receive DER encoded bytes instead of PEM.
 
 ## Entry Point
 
-This package registers `SelfSignedCertificate` under the `swarmauri.cert_services` entry point.
+This package registers `SelfSignedCertificate` under both the `swarmauri.cert_services` and `peagen.plugins.cert_services` entry points.

--- a/pkgs/standards/swarmauri_certs_self_signed/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_self_signed/pyproject.toml
@@ -37,6 +37,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Documentation-backed usage examples",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_certs_self_signed/tests/example/test_readme_quickstart.py
+++ b/pkgs/standards/swarmauri_certs_self_signed/tests/example/test_readme_quickstart.py
@@ -1,0 +1,52 @@
+"""Execute the README quickstart example to ensure it stays runnable."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+README_PATH = Path(__file__).resolve().parents[2] / "README.md"
+
+
+def _extract_quickstart_code() -> str:
+    text = README_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    in_quickstart = False
+    in_code = False
+    code_lines: list[str] = []
+
+    for line in lines:
+        if line.strip().lower() == "## quickstart":
+            in_quickstart = True
+            continue
+
+        if in_quickstart:
+            if line.startswith("```python"):
+                in_code = True
+                continue
+            if line.startswith("```") and in_code:
+                break
+            if in_code:
+                code_lines.append(line)
+                continue
+            if line.startswith("## "):
+                break
+
+    if not code_lines:
+        raise AssertionError("Quickstart python example not found in README.md")
+
+    return "\n".join(code_lines)
+
+
+@pytest.mark.example
+def test_readme_quickstart_example_runs() -> None:
+    code = _extract_quickstart_code()
+    namespace: dict[str, object] = {}
+    exec(compile(code, str(README_PATH), "exec"), namespace)
+
+    certificate = namespace.get("certificate_pem")
+    assert isinstance(certificate, bytes)
+    assert certificate.startswith(b"-----BEGIN CERTIFICATE-----")


### PR DESCRIPTION
## Summary
- document the self-signed certificate builder features along with pip, Poetry, and uv installation commands
- add an Ed25519 TLS quickstart example that aligns with the `SelfSignedCertificate` convenience constructor
- execute the README example in a pytest marked `example` and register the marker to keep the docs tested without warnings

## Testing
- `uv run --directory pkgs/standards/swarmauri_certs_self_signed --package swarmauri_certs_self_signed pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ca774949ec8331961f44b18eed23a0