### PR TITLE
Add unit tests for CompositeCertService certificate suite

### DIFF
--- a/pkgs/standards/swarmauri_certs_composite/tests/unit/CompositeCertService_unit_test.py
+++ b/pkgs/standards/swarmauri_certs_composite/tests/unit/CompositeCertService_unit_test.py
@@ -1,0 +1,69 @@
+import json
+
+import pytest
+
+from swarmauri_certs_composite import CompositeCertService
+from swarmauri_core.certs.ICertService import ICertService
+
+
+class DummyCertService(ICertService):
+    type = "DummyCertService"
+
+    def supports(self):
+        return {
+            "features": (
+                "csr",
+                "self_signed",
+                "sign_from_csr",
+                "verify",
+                "parse",
+            )
+        }
+
+    async def create_csr(self, *args, **kwargs):
+        return b"csr"
+
+    async def create_self_signed(self, *args, **kwargs):
+        return b"self-signed"
+
+    async def sign_cert(self, *args, **kwargs):
+        return b"cert"
+
+    async def verify_cert(self, *args, **kwargs):
+        return {"status": "ok"}
+
+    async def parse_cert(self, *args, **kwargs):
+        return {"parsed": True}
+
+
+@pytest.fixture
+def cipher_suite():
+    return CompositeCertService([DummyCertService()])
+
+
+@pytest.mark.unit
+def test_ubc_resource(cipher_suite):
+    assert cipher_suite.resource == "Crypto"
+
+
+@pytest.mark.unit
+def test_ubc_type(cipher_suite):
+    assert cipher_suite.type == "CompositeCertService"
+
+
+@pytest.mark.unit
+def test_initialization(cipher_suite):
+    assert isinstance(cipher_suite.id, str)
+
+
+@pytest.mark.unit
+def test_serialization(cipher_suite):
+    serialized = cipher_suite.model_dump_json()
+    data = json.loads(serialized)
+
+    restored = CompositeCertService.model_construct(**data)
+    restored._providers = cipher_suite._providers
+
+    assert restored.id == cipher_suite.id
+    assert restored.resource == cipher_suite.resource
+    assert restored.type == cipher_suite.type


### PR DESCRIPTION
## Summary
- add a dummy certificate provider fixture to instantiate `CompositeCertService`
- cover resource, type, identifier, and JSON serialization behavior for the composite cert suite

## Testing
- pytest pkgs/standards/swarmauri_certs_composite/tests/unit

------
https://chatgpt.com/codex/tasks/task_b_68dfc0fcfe6883319642ad7f6669ffa9